### PR TITLE
JENKINS-57142 - foundFailureCauses returning blank with new versions of Build Failure Analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bin
 .classpath
 .settings
 .project
+.idea
 *.iml
 *.ipr
 *.iws

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 1.1.2 - 2017-04-11
+- Fix NullPointerException for not configured Booleans
+- Fix bad configuration meaning and default values
+
 ## 1.1.1 - 2017-02-15
 - Fix a bug that was preventing an event being send for a build in a pipeline
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 1.1.3 - 2018-04-26
+
+- Luca Milanesio started as additional maintainer
+- [JENKINS-43440](https://issues.jenkins-ci.org/browse/JENKINS-43440) Support for pipeline jobs
+- Do not send events to HTTP endspoint by default
+- Use blank URLs as defaults for endpoints
+- Fails gracefully when HTTP notification fails
+- docs: corrected link to component bugs
+- add ScmInfo on build completion
+
 ## 1.1.2 - 2017-04-11
 - Fix NullPointerException for not configured Booleans
 - Fix bad configuration meaning and default values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 2.0 - 2018-04-30
+
+- Allow the send events to LOGBack appenders
+- Upgrade plugin version and target to Jenkins 2.x
+
 ## 1.1.3 - 2018-04-26
 
 - Luca Milanesio started as additional maintainer
@@ -12,18 +17,21 @@ All notable changes to this project will be documented in this file.
 - add ScmInfo on build completion
 
 ## 1.1.2 - 2017-04-11
+
 - Fix NullPointerException for not configured Booleans
 - Fix bad configuration meaning and default values
 
 ## 1.1.1 - 2017-02-15
+
 - Fix a bug that was preventing an event being send for a build in a pipeline
 
 ## 1.1.0 - 2017-01-12
+
 - Add functionnality to publish on AWS SNS. 
 - Update readme to expose Changelog.
 - Better unit test coverage
 
 
 ## 1.0.1 - 2016-07-26
-###
+
 - First official release on Jenkins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 2.0.2 - 2018-05-08
+
+- [JENKINS-51085](https://issues.jenkins-ci.org/browse/JENKINS-51085) Auto-reload LOGBack config XML
+
 ## 2.0.1 - 2018-05-02
 
 - Disable LOGBack when [LOGBack NATS Appender](https://plugins.jenkins.io/logback-nats-appender) is not installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## 1.0.2 [Unreleased yet]
+## 1.1.0 - 2017-01-12
+- Add functionnality to publish on AWS SNS. 
 - Update readme to expose Changelog.
 - Better unit test coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 1.1.1 - 2017-02-15
+- Fix a bug that was preventing an event being send for a build in a pipeline
+
 ## 1.1.0 - 2017-01-12
 - Add functionnality to publish on AWS SNS. 
 - Update readme to expose Changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 2.0.1 - 2018-05-02
+
+- Disable LOGBack when [LOGBack NATS Appender](https://plugins.jenkins.io/logback-nats-appender) is not installed
+- Disable HTTP log notification by default, unless explicitly configured
+
 ## 2.0 - 2018-04-30
 
 - Allow the send events to LOGBack appenders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+## 1.0.1 - 2016-07-26
+###
+- First official release on Jenkins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 1.0.2 [Unreleased yet]
+- Update readme to expose Changelog.
+- Better unit test coverage
+
+
 ## 1.0.1 - 2016-07-26
 ###
 - First official release on Jenkins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 2.0.3 - 2018-05-11
+
+- [JENKINS-51266](https://issues.jenkins-ci.org/browse/JENKINS-51266) Flag the plugin as dynamically-loadable
+
 ## 2.0.2 - 2018-05-08
 
 - [JENKINS-51085](https://issues.jenkins-ci.org/browse/JENKINS-51085) Auto-reload LOGBack config XML

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This plugin gather information on specific events on jenkins and sends them to a
 Issues
 ==========
 
-If you have an issue with this plugin, please open a ticket here: https://issues.jenkins-ci.org under the component `statistics-gatherer-plugin`
+If you have an issue with this plugin, please open a ticket on [issues.jenkins-ci.org](https://issues.jenkins-ci.org/issues/?jql=component%20%3D%20statistics-gatherer-plugin) using `statistics-gatherer-plugin` component.
 
 Documentation
 ==============

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Jenkins Statistics gatherer Plugin
 
 This plugin gather information on specific events on jenkins and sends them to an external API. That way, you can get the statistics that matters for your needs.
 
+Issues
+==========
+
+If you have an issue with this plugin, please open a ticket here: https://issues.jenkins-ci.org under the component `statistics-gatherer-plugin`
+
 Documentation
 ==============
 In this section, you'll see which data is sent when. Please note that we do not consider adding a field to a JSON as a breaking change. However, removing one is considered as a breaking change.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/maximecharron/statistics-gatherer-plugin.svg?branch=master)](https://travis-ci.org/maximecharron/statistics-gatherer-plugin)   [![Coverage Status](https://coveralls.io/repos/github/maximecharron/statistics-gatherer-plugin/badge.svg?branch=master)](https://coveralls.io/github/maximecharron/statistics-gatherer-plugin?branch=master)
+[![Build Status](https://travis-ci.org/jenkinsci/statistics-gatherer-plugin.svg?branch=master)](https://travis-ci.org/jenkinsci/statistics-gatherer-plugin)   [![Coverage Status](https://coveralls.io/repos/github/jenkinsci/statistics-gatherer-plugin/badge.svg?branch=master)](https://coveralls.io/github/jenkinsci/statistics-gatherer-plugin?branch=master)
 
 
 Jenkins Statistics gatherer Plugin
@@ -299,6 +299,10 @@ Plugin releases
 ---------------
 
 	mvn release:prepare release:perform -Dusername=user -Dpassword=******
+
+Changelog
+--------------
+Please refer to the CHANGELOG.md file. 
 
 
 License

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/jenkinsci/statistics-gatherer-plugin.svg?branch=master)](https://travis-ci.org/jenkinsci/statistics-gatherer-plugin)   [![Coverage Status](https://coveralls.io/repos/github/jenkinsci/statistics-gatherer-plugin/badge.svg?branch=master)](https://coveralls.io/github/jenkinsci/statistics-gatherer-plugin?branch=master)
+[![Build Status](https://travis-ci.org/jenkinsci/statistics-gatherer-plugin.svg?branch=statistics-gatherer-2.0.2)](https://travis-ci.org/jenkinsci/statistics-gatherer-plugin)   [![Coverage Status](https://coveralls.io/repos/github/jenkinsci/statistics-gatherer-plugin/badge.svg?branch=statistics-gatherer-2.0.2)](https://coveralls.io/github/jenkinsci/statistics-gatherer-plugin?branch=statistics-gatherer-2.0.2)
 
 
 Jenkins Statistics gatherer Plugin

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,11 @@
             <email>charron.maxime97@gmail.com</email>
         </developer>
         <developer>
+            <id>lucamilanesio</id>
+            <name>Luca Milanesio</name>
+            <email>luca.milanesio@gmail.com</email>
+        </developer>
+        <developer>
             <id>alexgandy</id>
             <name>Alex Gandy</name>
             <email>alexgandy@gmail.com</email>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,9 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <powermock.version>1.6.5</powermock.version>
-        <jenkins.version>1.645</jenkins.version>
+        <jenkins.version>2.60.1</jenkins.version>
+        <java.level>8</java.level>
+        <powermock.version>1.7.4</powermock.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -117,13 +118,13 @@
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-war</artifactId>
             <type>war</type>
-            <version>1.650</version>
+            <version>${jenkins.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
-            <version>1.644</version>
+            <version>${jenkins-test-harness.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -167,7 +168,6 @@
                 <!-- version specified in grandparent pom -->
                 <extensions>true</extensions>
                 <configuration>
-                    <showDeprecation>true</showDeprecation>
                     <disabledTestInjection>true</disabledTestInjection>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.1.3</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>statistics-gatherer-1.1.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-test-harness</artifactId>
+            <version>1.644</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.3</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>HEAD</tag>
+      <tag>statistics-gatherer-1.1.3</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>statistics-gatherer-2.0.1</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>statistics-gatherer-1.1.2</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>statistics-gatherer-1.1.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.2</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>HEAD</tag>
+      <tag>statistics-gatherer-2.0.2</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.7.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>logback-nats-appender</artifactId>
+            <version>0.2.2</version>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test dependancies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,13 @@
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.2.0</version>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>HEAD</tag>
+      <tag>statistics-gatherer-2.0.1</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>HEAD</tag>
+      <tag>statistics-gatherer-1.1.0</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>HEAD</tag>
+      <tag>statistics-gatherer-2.0</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
             <name>Maxime Charron</name>
             <email>charron.maxime97@gmail.com</email>
         </developer>
+        <developer>
+            <id>alexgandy</id>
+            <name>Alex Gandy</name>
+            <email>alexgandy@gmail.com</email>
+        </developer>
     </developers>
 
     <licenses>
@@ -55,7 +60,22 @@
         <powermock.version>1.6.5</powermock.version>
         <jenkins.version>1.645</jenkins.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>1.11.22</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.mashape.unirest</groupId>
             <artifactId>unirest-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>statistics-gatherer-1.1.1</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>2.7</version>
-        <relativePath />
+        <relativePath/>
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,8 +23,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>2.0</version>
+    <version>2.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>statistics-gatherer-2.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.1</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>HEAD</tag>
+      <tag>statistics-gatherer-1.1.1</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.6</version>
+            <version>4.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>2.0.3</version>
+    <version>2.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>statistics-gatherer-2.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.0.3</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>HEAD</tag>
+      <tag>statistics-gatherer-2.0.3</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>2.7</version>
-        <relativePath/>
+        <relativePath />
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -23,7 +22,8 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-    </scm>
+      <tag>statistics-gatherer-1.0.1</tag>
+  </scm>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>statistics-gatherer-1.0.1</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>statistics-gatherer-1.0.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>2.0.2</version>
+    <version>2.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>statistics-gatherer-2.0.2</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.0.3-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>2.7</version>
-        <relativePath />
+        <relativePath/>
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,8 +23,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>statistics-gatherer-1.0.0</tag>
-  </scm>
+    </scm>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.2</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -22,7 +22,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-      <tag>HEAD</tag>
+      <tag>statistics-gatherer-1.1.2</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>2.7</version>
-        <relativePath/>
+        <relativePath />
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -23,7 +22,8 @@
         <connection>scm:git:ssh://github.com/jenkinsci/statistics-gatherer-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/statistics-gatherer-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/statistics-gatherer-plugin</url>
-    </scm>
+      <tag>statistics-gatherer-1.0.0</tag>
+  </scm>
 
     <developers>
         <developer>

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
@@ -27,6 +27,7 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     private String awsAccessKey;
     private String awsSecretKey;
     private String snsTopicArn;
+    private String logbackConfigXmlUrl;
 
     private Boolean queueInfo;
     private Boolean buildInfo;
@@ -35,6 +36,8 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     private Boolean buildStepInfo;
     private Boolean shouldSendApiHttpRequests;
     private Boolean shouldPublishToAwsSnsQueue;
+
+    private Boolean shouldSendToLogback;
 
     public StatisticsConfiguration() {
         load();
@@ -358,5 +361,21 @@ public class StatisticsConfiguration extends GlobalConfiguration {
 
     private boolean validateProtocolUsed(String url) {
         return !(url.startsWith("http://") || url.startsWith("https://"));
+    }
+
+    public Boolean getShouldSendToLogback() {
+        return shouldSendToLogback;
+    }
+
+    public void setShouldSendToLogback(Boolean shouldSendToLogback) {
+        this.shouldSendToLogback = shouldSendToLogback;
+    }
+
+    public String getLogbackConfigXmlUrl() {
+        return logbackConfigXmlUrl;
+    }
+
+    public void setLogbackConfigXmlUrl(String logbackConfigXmlUrl) {
+        this.logbackConfigXmlUrl = logbackConfigXmlUrl;
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
@@ -309,7 +309,7 @@ public class StatisticsConfiguration extends GlobalConfiguration {
 
     public FormValidation doCheckAwsRegion(
         @QueryParameter("awsRegion") final String awsRegion) {
-        if (shouldPublishToAwsSnsQueue) {
+        if (shouldPublishToAwsSnsQueue == null ||shouldPublishToAwsSnsQueue ) {
             if (awsRegion == null) {
                 return FormValidation.error("AWS Region required. ");
             }
@@ -325,7 +325,7 @@ public class StatisticsConfiguration extends GlobalConfiguration {
 
     public FormValidation doCheckSnsTopicArn(
             @QueryParameter("snsTopicArn") final String snsTopicArn) {
-        if (shouldPublishToAwsSnsQueue) {
+        if (shouldPublishToAwsSnsQueue == null ||shouldPublishToAwsSnsQueue ) {
             if (snsTopicArn == null || snsTopicArn.isEmpty()) {
                 return FormValidation.error("SNS ARN required. ");
             }
@@ -336,7 +336,7 @@ public class StatisticsConfiguration extends GlobalConfiguration {
 
     public FormValidation doCheckAwsAccessKey(
             @QueryParameter("awsAccessKey") final String awsAccessKey) {
-        if (shouldPublishToAwsSnsQueue) {
+        if (shouldPublishToAwsSnsQueue == null ||shouldPublishToAwsSnsQueue ) {
             if (awsAccessKey == null || awsAccessKey.isEmpty()) {
                 return FormValidation.error("AWS Access Key required. ");
             }
@@ -347,7 +347,7 @@ public class StatisticsConfiguration extends GlobalConfiguration {
 
     public FormValidation doCheckAwsSecretKey(
             @QueryParameter("awsSecretKey") final String awsSecretKey) {
-        if (shouldPublishToAwsSnsQueue) {
+        if (shouldPublishToAwsSnsQueue == null ||shouldPublishToAwsSnsQueue ) {
             if (awsSecretKey == null || awsSecretKey.isEmpty()) {
                 return FormValidation.error("AWS Secret Key required. ");
             }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
@@ -16,7 +16,6 @@ import com.amazonaws.regions.RegionUtils;
 @Extension(dynamicLoadable = YesNoMaybe.YES)
 public class StatisticsConfiguration extends GlobalConfiguration {
 
-    private static final String SLASH = "/";
     public static final String PROTOCOL_ERROR_MESSAGE = "Only http and https protocols are supported";
 
     private String queueUrl;
@@ -49,12 +48,6 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     }
 
     public String getQueueUrl() {
-        if (queueUrl != null && !queueUrl.isEmpty()) {
-            if (queueUrl.endsWith(SLASH)) {
-                return queueUrl;
-            }
-            return queueUrl + SLASH;
-        }
         return queueUrl;
     }
 
@@ -109,12 +102,6 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     }
 
     public String getBuildUrl() {
-        if (buildUrl != null && !buildUrl.isEmpty()) {
-            if (buildUrl.endsWith(SLASH)) {
-                return buildUrl;
-            }
-            return buildUrl + SLASH;
-        }
         return buildUrl;
     }
 
@@ -124,12 +111,6 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     }
 
     public String getProjectUrl() {
-        if (projectUrl != null && !projectUrl.isEmpty()) {
-            if (projectUrl.endsWith(SLASH)) {
-                return projectUrl;
-            }
-            return projectUrl + SLASH;
-        }
         return projectUrl;
     }
 
@@ -139,12 +120,6 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     }
 
     public String getBuildStepUrl() {
-        if (buildStepUrl != null && !buildStepUrl.isEmpty()) {
-            if (buildStepUrl.endsWith(SLASH)) {
-                return buildStepUrl;
-            }
-            return buildStepUrl + SLASH;
-        }
         return buildStepUrl;
     }
 
@@ -154,12 +129,6 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     }
 
     public String getScmCheckoutUrl() {
-        if (scmCheckoutUrl != null && !scmCheckoutUrl.isEmpty()) {
-            if (scmCheckoutUrl.endsWith(SLASH)) {
-                return scmCheckoutUrl;
-            }
-            return scmCheckoutUrl + SLASH;
-        }
         return scmCheckoutUrl;
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
@@ -3,6 +3,7 @@ package org.jenkins.plugins.statistics.gatherer;
 import com.amazonaws.regions.Region;
 import hudson.Extension;
 import hudson.util.FormValidation;
+import jenkins.YesNoMaybe;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.QueryParameter;
@@ -12,7 +13,7 @@ import com.amazonaws.regions.RegionUtils;
 /**
  * Created by hthakkallapally on 6/25/2015.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class StatisticsConfiguration extends GlobalConfiguration {
 
     private static final String SLASH = "/";

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
@@ -5,7 +5,6 @@ import hudson.Extension;
 import hudson.util.FormValidation;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
-import org.apache.commons.logging.Log;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import com.amazonaws.regions.RegionUtils;
@@ -27,7 +26,7 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     private String awsRegion;
     private String awsAccessKey;
     private String awsSecretKey;
-    private String snsArn;
+    private String snsTopicArn;
 
     private Boolean queueInfo;
     private Boolean buildInfo;
@@ -186,10 +185,10 @@ public class StatisticsConfiguration extends GlobalConfiguration {
         save();
     }
 
-    public String getSnsArn() { return snsArn; }
+    public String getSnsTopicArn() { return snsTopicArn; }
 
-    public void setSnsArn(String snsArn) {
-        this.snsArn = snsArn;
+    public void setSnsTopicArn(String snsTopicArn) {
+        this.snsTopicArn = snsTopicArn;
         save();
     }
 
@@ -324,10 +323,10 @@ public class StatisticsConfiguration extends GlobalConfiguration {
         return FormValidation.ok();
     }
 
-    public FormValidation doCheckSnsArn(
-            @QueryParameter("snsArn") final String snsArn) {
+    public FormValidation doCheckSnsTopicArn(
+            @QueryParameter("snsTopicArn") final String snsTopicArn) {
         if (shouldPublishToAwsSnsQueue) {
-            if (snsArn == null || snsArn.isEmpty()) {
+            if (snsTopicArn == null || snsTopicArn.isEmpty()) {
                 return FormValidation.error("SNS ARN required. ");
             }
         }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
@@ -1,11 +1,14 @@
 package org.jenkins.plugins.statistics.gatherer;
 
+import com.amazonaws.regions.Region;
 import hudson.Extension;
 import hudson.util.FormValidation;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
+import org.apache.commons.logging.Log;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import com.amazonaws.regions.RegionUtils;
 
 /**
  * Created by hthakkallapally on 6/25/2015.
@@ -21,12 +24,18 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     private String projectUrl;
     private String scmCheckoutUrl;
     private String buildStepUrl;
+    private String awsRegion;
+    private String awsAccessKey;
+    private String awsSecretKey;
+    private String snsArn;
 
     private Boolean queueInfo;
     private Boolean buildInfo;
     private Boolean projectInfo;
     private Boolean scmCheckoutInfo;
     private Boolean buildStepInfo;
+    private Boolean shouldSendApiHttpRequests;
+    private Boolean shouldPublishToAwsSnsQueue;
 
     public StatisticsConfiguration() {
         load();
@@ -91,7 +100,6 @@ public class StatisticsConfiguration extends GlobalConfiguration {
         save();
     }
 
-
     public void setQueueUrl(String queueUrl) {
         this.queueUrl = queueUrl;
         save();
@@ -154,6 +162,48 @@ public class StatisticsConfiguration extends GlobalConfiguration {
 
     public void setScmCheckoutUrl(String scmCheckoutUrl) {
         this.scmCheckoutUrl = scmCheckoutUrl;
+        save();
+    }
+
+    public String getAwsRegion() { return awsRegion; }
+
+    public void setAwsRegion(String awsRegion) {
+        this.awsRegion = awsRegion;
+        save();
+    }
+
+    public String getAwsAccessKey() { return awsAccessKey; }
+
+    public void setAwsAccessKey(String awsAccessKey) {
+        this.awsAccessKey = awsAccessKey;
+        save();
+    }
+
+    public String getAwsSecretKey() { return awsSecretKey; }
+
+    public void setAwsSecretKey(String awsSecretKey) {
+        this.awsSecretKey = awsSecretKey;
+        save();
+    }
+
+    public String getSnsArn() { return snsArn; }
+
+    public void setSnsArn(String snsArn) {
+        this.snsArn = snsArn;
+        save();
+    }
+
+    public Boolean getShouldSendApiHttpRequests() { return shouldSendApiHttpRequests; }
+
+    public void setShouldSendApiHttpRequests(Boolean shouldSendApiHttpRequests) {
+        this.shouldSendApiHttpRequests = shouldSendApiHttpRequests;
+        save();
+    }
+
+    public Boolean getShouldPublishToAwsSnsQueue() { return shouldPublishToAwsSnsQueue; }
+
+    public void setShouldPublishToAwsSnsQueue(Boolean shouldPublishToAwsSnsQueue) {
+        this.shouldPublishToAwsSnsQueue = shouldPublishToAwsSnsQueue;
         save();
     }
 
@@ -242,7 +292,6 @@ public class StatisticsConfiguration extends GlobalConfiguration {
         return FormValidation.ok();
     }
 
-
     public FormValidation doCheckBuildStepInfo(
             @QueryParameter("buildStepInfo") final Boolean buildStepInfo) {
         if (buildStepInfo == null) {
@@ -256,6 +305,55 @@ public class StatisticsConfiguration extends GlobalConfiguration {
         if (scmCheckoutInfo == null) {
             return FormValidation.error("Provide valid CcmCheckoutInfo. ");
         }
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckAwsRegion(
+        @QueryParameter("awsRegion") final String awsRegion) {
+        if (shouldPublishToAwsSnsQueue) {
+            if (awsRegion == null) {
+                return FormValidation.error("AWS Region required. ");
+            }
+
+            Region r = RegionUtils.getRegion(awsRegion);
+            if (r == null || !r.isServiceSupported("sns")) {
+                return FormValidation.error("Please enter a valid SNS AWS region. ");
+            }
+        }
+
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckSnsArn(
+            @QueryParameter("snsArn") final String snsArn) {
+        if (shouldPublishToAwsSnsQueue) {
+            if (snsArn == null || snsArn.isEmpty()) {
+                return FormValidation.error("SNS ARN required. ");
+            }
+        }
+
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckAwsAccessKey(
+            @QueryParameter("awsAccessKey") final String awsAccessKey) {
+        if (shouldPublishToAwsSnsQueue) {
+            if (awsAccessKey == null || awsAccessKey.isEmpty()) {
+                return FormValidation.error("AWS Access Key required. ");
+            }
+        }
+
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckAwsSecretKey(
+            @QueryParameter("awsSecretKey") final String awsSecretKey) {
+        if (shouldPublishToAwsSnsQueue) {
+            if (awsSecretKey == null || awsSecretKey.isEmpty()) {
+                return FormValidation.error("AWS Secret Key required. ");
+            }
+        }
+
         return FormValidation.ok();
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
@@ -6,6 +6,7 @@ import hudson.model.BuildListener;
 import hudson.model.BuildStepListener;
 import hudson.tasks.BuildStep;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
 import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
@@ -29,6 +30,7 @@ public class BuildStepStatsListener extends BuildStepListener {
             buildStepStats.setStartTime(new Date(0));
             RestClientUtil.postToService(getRestUrl(), buildStepStats);
             SnsClientUtil.publishToSns(buildStepStats);
+            LogbackUtil.info(buildStepStats);
         }
     }
 
@@ -43,6 +45,7 @@ public class BuildStepStatsListener extends BuildStepListener {
             buildStepStats.setEndTime(new Date(0));
             RestClientUtil.postToService(getRestUrl(), buildStepStats);
             SnsClientUtil.publishToSns(buildStepStats);
+            LogbackUtil.info(buildStepStats);
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
@@ -5,6 +5,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.BuildStepListener;
 import hudson.tasks.BuildStep;
+import jenkins.YesNoMaybe;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
 import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
@@ -16,7 +17,7 @@ import java.util.Date;
 /**
  * Created by mcharron on 2016-07-12.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class BuildStepStatsListener extends BuildStepListener {
 
     @Override

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
@@ -8,6 +8,7 @@ import hudson.tasks.BuildStep;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
 
 import java.util.Date;
 
@@ -27,6 +28,7 @@ public class BuildStepStatsListener extends BuildStepListener {
             buildStepStats.setEndTime(new Date());
             buildStepStats.setStartTime(new Date(0));
             RestClientUtil.postToService(getRestUrl(), buildStepStats);
+            SnsClientUtil.publishToSns(buildStepStats);
         }
     }
 
@@ -40,6 +42,7 @@ public class BuildStepStatsListener extends BuildStepListener {
             buildStepStats.setStartTime(new Date());
             buildStepStats.setEndTime(new Date(0));
             RestClientUtil.postToService(getRestUrl(), buildStepStats);
+            SnsClientUtil.publishToSns(buildStepStats);
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
@@ -30,12 +30,9 @@ public class ItemStatsListener extends ItemListener {
 
     @Override
     public void onCreated(Item item) {
-        if (PropertyLoader.getProjectInfo()) {
+        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
             try {
-                if (item == null) {
-                    return;
-                }
-                AbstractProject<?, ?> project = (AbstractProject<?, ?>) item;
+                AbstractProject<?, ?> project = asProject(item);
                 JobStats ciJob = addCIJobData(project);
                 ciJob.setCreatedDate(new Date());
                 ciJob.setStatus(Constants.ACTIVE);
@@ -46,6 +43,18 @@ public class ItemStatsListener extends ItemListener {
                 logException(item, e);
             }
         }
+    }
+
+    private AbstractProject<?, ?> asProject(Item item) {
+        if(canHandle(item)) {
+            return (AbstractProject<?, ?>) item;
+        } else {
+            throw new IllegalArgumentException("Discarding item " + item.getDisplayName() + "/" + item.getClass() + " because it is not an AbstractProject");
+        }
+    }
+
+    private boolean canHandle(Item item) {
+        return item instanceof AbstractProject<?, ?>;
     }
 
     private void logException(Item item, Exception e) {
@@ -98,12 +107,9 @@ public class ItemStatsListener extends ItemListener {
 
     @Override
     public void onUpdated(Item item) {
-        if (PropertyLoader.getProjectInfo()) {
-            AbstractProject<?, ?> project = (AbstractProject<?, ?>) item;
+        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
+            AbstractProject<?, ?> project = asProject(item);
             try {
-                if (item == null) {
-                    return;
-                }
                 JobStats ciJob = addCIJobData(project);
                 ciJob.setUpdatedDate(new Date());
                 ciJob.setStatus(project.isDisabled() ? Constants.DISABLED : Constants.ACTIVE);
@@ -118,12 +124,9 @@ public class ItemStatsListener extends ItemListener {
 
     @Override
     public void onDeleted(Item item) {
-        if (PropertyLoader.getProjectInfo()) {
-            AbstractProject<?, ?> project = (AbstractProject<?, ?>) item;
+        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
+            AbstractProject<?, ?> project = asProject(item);
             try {
-                if (item == null) {
-                    return;
-                }
                 JobStats ciJob = addCIJobData(project);
                 ciJob.setUpdatedDate(new Date());
                 ciJob.setStatus(Constants.DELETED);

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
@@ -5,6 +5,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Item;
 import hudson.model.User;
 import hudson.model.listeners.ItemListener;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
 import org.jenkins.plugins.statistics.gatherer.util.*;
@@ -17,7 +18,7 @@ import java.util.logging.Logger;
 /**
  * Created by hthakkallapally on 3/12/2015.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class ItemStatsListener extends ItemListener {
     private static final Logger LOGGER = Logger.getLogger(ItemStatsListener.class.getName());
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
@@ -10,6 +10,7 @@ import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
 import org.jenkins.plugins.statistics.gatherer.util.Constants;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
 
 import java.io.IOException;
 import java.util.Date;
@@ -40,6 +41,7 @@ public class ItemStatsListener extends ItemListener {
                 ciJob.setStatus(Constants.ACTIVE);
                 setConfig(project, ciJob);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
+                SnsClientUtil.publishToSns(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -107,6 +109,7 @@ public class ItemStatsListener extends ItemListener {
                 ciJob.setStatus(project.isDisabled() ? Constants.DISABLED : Constants.ACTIVE);
                 setConfig(project, ciJob);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
+                SnsClientUtil.publishToSns(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -125,6 +128,7 @@ public class ItemStatsListener extends ItemListener {
                 ciJob.setUpdatedDate(new Date());
                 ciJob.setStatus(Constants.DELETED);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
+                SnsClientUtil.publishToSns(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
@@ -7,10 +7,7 @@ import hudson.model.User;
 import hudson.model.listeners.ItemListener;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
-import org.jenkins.plugins.statistics.gatherer.util.Constants;
-import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
-import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
-import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.*;
 
 import java.io.IOException;
 import java.util.Date;
@@ -39,6 +36,7 @@ public class ItemStatsListener extends ItemListener {
                 setConfig(project, ciJob);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
                 SnsClientUtil.publishToSns(ciJob);
+                LogbackUtil.info(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -84,8 +82,10 @@ public class ItemStatsListener extends ItemListener {
         ciJob.setJobUrl(project.getUrl());
         String userName = Jenkins.getAuthentication().getName();
         User user = Jenkins.getInstance().getUser(userName);
-        ciJob.setUserId(user.getId());
-        ciJob.setUserName(user.getFullName());
+        if(user != null) {
+            ciJob.setUserId(user.getId());
+            ciJob.setUserName(user.getFullName());
+        }
 
         return ciJob;
     }
@@ -116,6 +116,7 @@ public class ItemStatsListener extends ItemListener {
                 setConfig(project, ciJob);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
                 SnsClientUtil.publishToSns(ciJob);
+                LogbackUtil.info(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -132,6 +133,7 @@ public class ItemStatsListener extends ItemListener {
                 ciJob.setStatus(Constants.DELETED);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
                 SnsClientUtil.publishToSns(ciJob);
+                LogbackUtil.info(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
@@ -6,6 +6,7 @@ import hudson.model.Queue.*;
 import hudson.model.queue.QueueListener;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.queue.QueueCause;
 import org.jenkins.plugins.statistics.gatherer.model.queue.QueueStats;
@@ -19,7 +20,7 @@ import java.util.logging.Logger;
 /**
  * Created by hthakkallapally on 3/13/2015.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class QueueStatsListener extends QueueListener {
     private static final Logger LOGGER = Logger.getLogger(
             QueueStatsListener.class.getName());

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
@@ -41,6 +41,7 @@ public class QueueStatsListener extends QueueListener {
                     addEntryQueueCause("waiting", waitingItem, queue);
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionWaiting(waitingItem, e);
             }
@@ -73,6 +74,7 @@ public class QueueStatsListener extends QueueListener {
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionWaiting(waitingItem, e);
             }
@@ -127,6 +129,7 @@ public class QueueStatsListener extends QueueListener {
 
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionBlocked(blockedItem, e);
             }
@@ -143,6 +146,7 @@ public class QueueStatsListener extends QueueListener {
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionLeave(buildableItem, e);
             }
@@ -159,6 +163,7 @@ public class QueueStatsListener extends QueueListener {
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionLeave(buildableItem, e);
             }
@@ -215,6 +220,7 @@ public class QueueStatsListener extends QueueListener {
                 queue.setContextId(leftItem.outcome.hashCode());
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionLeft(leftItem, e);
             }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
@@ -218,7 +218,9 @@ public class QueueStatsListener extends QueueListener {
                 queue.setExitTime(new Date());
                 queue.setStatus(Constants.LEFT);
                 queue.setDuration(System.currentTimeMillis() - leftItem.getInQueueSince());
-                queue.setContextId(leftItem.outcome.hashCode());
+                if (leftItem.outcome != null) {
+                    queue.setContextId(leftItem.outcome.hashCode());
+                }
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
                 LogbackUtil.info(queue);

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
@@ -9,10 +9,7 @@ import hudson.triggers.TimerTrigger;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.queue.QueueCause;
 import org.jenkins.plugins.statistics.gatherer.model.queue.QueueStats;
-import org.jenkins.plugins.statistics.gatherer.util.Constants;
-import org.jenkins.plugins.statistics.gatherer.util.JenkinsCauses;
-import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
-import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.*;
 
 import java.util.Date;
 import java.util.List;
@@ -75,6 +72,7 @@ public class QueueStatsListener extends QueueListener {
                     addExitQueueCause("waiting", waitingItem, queue);
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionWaiting(waitingItem, e);
             }
@@ -105,6 +103,7 @@ public class QueueStatsListener extends QueueListener {
                     addEntryQueueCause("blocked", blockedItem, queue);
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionBlocked(blockedItem, e);
             }
@@ -127,6 +126,7 @@ public class QueueStatsListener extends QueueListener {
                 }
 
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionBlocked(blockedItem, e);
             }
@@ -142,6 +142,7 @@ public class QueueStatsListener extends QueueListener {
                     addEntryQueueCause("buildable", buildableItem, queue);
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionLeave(buildableItem, e);
             }
@@ -157,6 +158,7 @@ public class QueueStatsListener extends QueueListener {
                     addExitQueueCause("buildable", buildableItem, queue);
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionLeave(buildableItem, e);
             }
@@ -212,6 +214,7 @@ public class QueueStatsListener extends QueueListener {
                 queue.setDuration(System.currentTimeMillis() - leftItem.getInQueueSince());
                 queue.setContextId(leftItem.outcome.hashCode());
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionLeft(leftItem, e);
             }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -65,6 +65,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 addSlaveInfo(run, build, listener);
                 RestClientUtil.postToService(getRestUrl(), build);
                 SnsClientUtil.publishToSns(build);
+                LogbackUtil.info(build);
                 LOGGER.log(Level.INFO, "Started build and its status is : " + buildResult +
                         " and start time is : " + run.getTimestamp().getTime());
             } catch (Exception e) {
@@ -226,6 +227,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 addBuildFailureCauses(build);
                 RestClientUtil.postToService(getRestUrl(), build);
                 SnsClientUtil.publishToSns(build);
+                LogbackUtil.info(build);
                 LOGGER.log(Level.INFO, run.getParent().getName() + " build is completed " +
                         "its status is : " + buildResult +
                         " at time : " + new Date());
@@ -272,6 +274,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
             scmCheckoutInfo.setEndTime(new Date(0));
             RestClientUtil.postToService(getScmCheckoutUrl(), scmCheckoutInfo);
             SnsClientUtil.publishToSns(scmCheckoutInfo);
+            LogbackUtil.info(scmCheckoutInfo);
         }
         return super.setUpEnvironment(build, launcher, listener);
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -8,6 +8,7 @@ import hudson.model.*;
 import hudson.model.listeners.RunListener;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.build.BuildStats;
 import org.jenkins.plugins.statistics.gatherer.model.build.SCMInfo;
@@ -27,7 +28,7 @@ import java.util.logging.Logger;
  *
  * @author hthakkallapally
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class RunStatsListener extends RunListener<Run<?, ?>> {
 
     private static final Logger LOGGER = Logger.getLogger(RunStatsListener.class.getName());

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -67,6 +67,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 addParameters(run, build);
                 addSlaveInfo(run, build, listener);
                 RestClientUtil.postToService(getRestUrl(), build);
+                SnsClientUtil.publishToSns(build);
                 LOGGER.log(Level.INFO, "Started build and its status is : " + buildResult +
                         " and start time is : " + run.getTimestamp().getTime());
             } catch (Exception e) {
@@ -230,6 +231,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 build.setEndTime(Calendar.getInstance().getTime());
                 addBuildFailureCauses(build);
                 RestClientUtil.postToService(getRestUrl(), build);
+                SnsClientUtil.publishToSns(build);
                 LOGGER.log(Level.INFO, run.getParent().getName() + " build is completed " +
                         "its status is : " + buildResult +
                         " at time : " + new Date());
@@ -275,6 +277,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
             scmCheckoutInfo.setBuildUrl(build.getUrl());
             scmCheckoutInfo.setEndTime(new Date(0));
             RestClientUtil.postToService(getScmCheckoutUrl(), scmCheckoutInfo);
+            SnsClientUtil.publishToSns(scmCheckoutInfo);
         }
         return super.setUpEnvironment(build, launcher, listener);
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -222,6 +222,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 build.setBuildUrl(run.getUrl());
                 build.setDuration(run.getDuration());
                 build.setEndTime(Calendar.getInstance().getTime());
+                addSCMInfo(run, SoutTaskListener.INSTANCE, build);
                 addBuildFailureCauses(build);
                 RestClientUtil.postToService(getRestUrl(), build);
                 SnsClientUtil.publishToSns(build);

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -45,9 +45,6 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
     public void onStarted(Run<?, ?> run, TaskListener listener) {
         if (PropertyLoader.getBuildInfo()) {
             try {
-                if (!(run instanceof AbstractBuild)) {
-                    return;
-                }
                 final String buildResult = run.getResult() == null ?
                         "INPROGRESS" : run.getResult().toString();
                 BuildStats build = new BuildStats();
@@ -214,10 +211,6 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
     public void onFinalized(final Run<?, ?> run) {
         if (PropertyLoader.getBuildInfo()) {
             try {
-                if (!(run instanceof AbstractBuild)) {
-                    return;
-                }
-
                 final String buildResult = run.getResult() == null ?
                         Constants.UNKNOWN : run.getResult().toString();
                 BuildStats build = new BuildStats();

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
@@ -9,6 +9,7 @@ import hudson.model.listeners.SCMListener;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import org.jenkins.plugins.statistics.gatherer.model.scm.ScmCheckoutInfo;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
 import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
@@ -35,6 +36,7 @@ public class ScmStatsListener extends SCMListener{
             scmCheckoutInfo.setEndTime(Calendar.getInstance().getTime());
             RestClientUtil.postToService(getUrl(), scmCheckoutInfo);
             SnsClientUtil.publishToSns(scmCheckoutInfo);
+            LogbackUtil.info(scmCheckoutInfo);
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
@@ -8,6 +8,7 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.SCMListener;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
+import jenkins.YesNoMaybe;
 import org.jenkins.plugins.statistics.gatherer.model.scm.ScmCheckoutInfo;
 import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
@@ -21,7 +22,7 @@ import java.util.Date;
 /**
  * Created by mcharron on 2016-07-15.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class ScmStatsListener extends SCMListener{
 
     @Override

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
@@ -11,6 +11,7 @@ import hudson.scm.SCMRevisionState;
 import org.jenkins.plugins.statistics.gatherer.model.scm.ScmCheckoutInfo;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
 
 import java.io.File;
 import java.util.Calendar;
@@ -33,6 +34,7 @@ public class ScmStatsListener extends SCMListener{
             scmCheckoutInfo.setStartTime(new Date(0));
             scmCheckoutInfo.setEndTime(Calendar.getInstance().getTime());
             RestClientUtil.postToService(getUrl(), scmCheckoutInfo);
+            SnsClientUtil.publishToSns(scmCheckoutInfo);
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/SoutTaskListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/SoutTaskListener.java
@@ -1,0 +1,49 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.console.ConsoleNote;
+import hudson.model.TaskListener;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+public class SoutTaskListener implements TaskListener {
+    private static PrintWriter soutWriter = new PrintWriter(System.out);
+
+    public static final SoutTaskListener INSTANCE = new SoutTaskListener();
+
+    @Override
+    public PrintStream getLogger() {
+        return System.out;
+    }
+
+    @Override
+    public void annotate(ConsoleNote ann) throws IOException {
+
+    }
+
+    @Override
+    public void hyperlink(String url, String text) throws IOException {
+
+    }
+
+    @Override
+    public PrintWriter error(String msg) {
+        return soutWriter;
+    }
+
+    @Override
+    public PrintWriter error(String format, Object... args) {
+        return soutWriter;
+    }
+
+    @Override
+    public PrintWriter fatalError(String msg) {
+        return soutWriter;
+    }
+
+    @Override
+    public PrintWriter fatalError(String format, Object... args) {
+        return soutWriter;
+    }
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/Constants.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/Constants.java
@@ -13,8 +13,7 @@ public final class Constants {
     public static final String SYSTEM = "SYSTEM";
     public static final String ANONYMOUS = "anonymous";
     public static final String UNKNOWN = "UNKNOWN";
-
-    private Constants() {
+    protected Constants() {
         throw new IllegalAccessError("Utility class");
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/JSONUtil.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/JSONUtil.java
@@ -16,7 +16,7 @@ public class JSONUtil {
 
     private static final Logger LOGGER = Logger.getLogger(
             RestClientUtil.class.getName());
-    private JSONUtil() {
+    protected JSONUtil() {
         throw new IllegalAccessError("Utility class");
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/JenkinsCauses.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/JenkinsCauses.java
@@ -8,8 +8,7 @@ public final class JenkinsCauses {
     public static final String UPSTREAM = "UPSTREAM";
     public static final String SCM = "SCM";
     public static final String TIMER = "TIMER";
-
-    private JenkinsCauses() {
+    protected JenkinsCauses() {
         throw new IllegalAccessError("Utility class");
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/Logback.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/Logback.java
@@ -1,0 +1,22 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+/**
+ * Subsystem to send logs through LOGBack
+ */
+public interface Logback {
+
+    /**
+     * Define the LOGBack logger name to use
+     *
+     * @param loggerName the logger name to use
+     * @return this instance
+     */
+    Logback setLoggerName(String loggerName);
+
+    /**
+     * Send the message to LOGBack
+     *
+     * @param msg message to send to LOGBack
+     */
+    void log(String msg);
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/Logback.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/Logback.java
@@ -13,10 +13,33 @@ public interface Logback {
      */
     Logback setLoggerName(String loggerName);
 
+
+    /**
+     * Get the current LOGBack logger name
+     *
+     * @return logger name
+     */
+    String getLoggerName();
+
     /**
      * Send the message to LOGBack
      *
      * @param msg message to send to LOGBack
      */
     void log(String msg);
+
+    /**
+     * Check for LOGBack configuration and reload when changed.
+     *
+     * @return true if the configuration has been reloaded
+     * @throws Exception if the configuration refresh failed
+     */
+    public boolean refresh() throws Exception;
+
+    /**
+     * Return the SHA of the latest LOGBack configuration loaded.
+     *
+     * @return the URLSha of the last loaded configuration
+     */
+    public URLSha getLastSha();
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackFactory.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackFactory.java
@@ -1,9 +1,44 @@
 package org.jenkins.plugins.statistics.gatherer.util;
 
-public class LogbackFactory {
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-    public static Logback create(String loggerName) throws Exception {
+public class LogbackFactory {
+    private static final Logger logger = Logger.getLogger(LogbackFactory.class.getName());
+    private static final int REFRESH_THREADS = 1;
+    private static final int REFRESH_INTERVAL_SECS = 60;
+    private static final ScheduledExecutorService refresher = Executors.newScheduledThreadPool(REFRESH_THREADS);
+    private static final Set<Logback> activeLogbacks = new HashSet<>();
+    private static ScheduledFuture<?> refresherTask;
+
+    public static synchronized Logback create(String loggerName) throws Exception {
         Class<Logback> logback = (Class<Logback>) Class.forName(Logback.class.getName() + "Impl");
-        return logback.newInstance().setLoggerName(loggerName);
+        Logback logbackInstance = logback.newInstance().setLoggerName(loggerName);
+
+        activeLogbacks.add(logbackInstance);
+
+        if(refresherTask != null && !refresherTask.isCancelled()) {
+            refresherTask.cancel(true);
+        }
+
+        refresherTask = refresher.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                for (Logback logback: activeLogbacks) {
+                    try {
+                        logback.refresh();
+                    } catch (Exception e) {
+                        logger.log(Level.WARNING, "Unable to refresh LOGBack " + logback, e);
+                    }
+                }
+            }
+        }, REFRESH_INTERVAL_SECS, REFRESH_INTERVAL_SECS, TimeUnit.SECONDS);
+
+        return logbackInstance;
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackFactory.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackFactory.java
@@ -1,0 +1,9 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+public class LogbackFactory {
+
+    public static Logback create(String loggerName) throws Exception {
+        Class<Logback> logback = (Class<Logback>) Class.forName(Logback.class.getName() + "Impl");
+        return logback.newInstance().setLoggerName(loggerName);
+    }
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImpl.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImpl.java
@@ -1,0 +1,45 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.spi.JoranException;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class LogbackImpl implements Logback {
+    private static Logger logger;
+
+    @Override
+    public Logback setLoggerName(String loggerName) {
+        LoggerContext loggerContext = new LoggerContext();
+        ContextInitializer contextInitializer = new ContextInitializer(loggerContext);
+        try {
+            String configurationUrlString = PropertyLoader.getLogbackConfigXmlUrl();
+            if (configurationUrlString == null) {
+                throw new IllegalStateException("LOGBack XML configuration file not specified");
+            }
+
+            URL configurationUrl = new URL(configurationUrlString);
+            contextInitializer.configureByResource(configurationUrl);
+            logger = loggerContext.getLogger(loggerName);
+            return this;
+        } catch (JoranException e) {
+            throw new RuntimeException("Unable to configure logger", e);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Unable to find LOGBack XML configuration", e);
+        }
+    }
+
+    @Override
+    public void log(String msg) {
+        if (logger != null) {
+            logger.info(msg);
+        }
+    }
+
+    public Logger getLogger() {
+        return logger;
+    }
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImpl.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImpl.java
@@ -5,31 +5,60 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.util.ContextInitializer;
 import ch.qos.logback.core.joran.spi.JoranException;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
 public class LogbackImpl implements Logback {
-    private static Logger logger;
+    private Logger logger;
+    private URLSha loggerSha;
+    private String loggerName;
 
     @Override
     public Logback setLoggerName(String loggerName) {
-        LoggerContext loggerContext = new LoggerContext();
-        ContextInitializer contextInitializer = new ContextInitializer(loggerContext);
         try {
-            String configurationUrlString = PropertyLoader.getLogbackConfigXmlUrl();
-            if (configurationUrlString == null) {
-                throw new IllegalStateException("LOGBack XML configuration file not specified");
-            }
-
-            URL configurationUrl = new URL(configurationUrlString);
-            contextInitializer.configureByResource(configurationUrl);
-            logger = loggerContext.getLogger(loggerName);
+            this.loggerName = loggerName;
+            URL configurationUrl = getConfigurationURL();
+            initLogger(configurationUrl, loggerName);
             return this;
         } catch (JoranException e) {
             throw new RuntimeException("Unable to configure logger", e);
         } catch (MalformedURLException e) {
             throw new RuntimeException("Unable to find LOGBack XML configuration", e);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to open LOGBack XML", e);
         }
+    }
+
+    @Override
+    public String getLoggerName() {
+        return loggerName;
+    }
+
+    public URLSha getLastSha() {
+        return loggerSha;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+
+    private void initLogger(URL configurationUrl, String loggerName) throws JoranException, IOException {
+        LoggerContext loggerContext = new LoggerContext();
+        ContextInitializer contextInitializer = new ContextInitializer(loggerContext);
+        contextInitializer.configureByResource(configurationUrl);
+        this.loggerSha = new URLSha(configurationUrl);
+        this.logger = loggerContext.getLogger(loggerName);
+    }
+
+    private URL getConfigurationURL() throws MalformedURLException {
+        String configurationUrlString = PropertyLoader.getLogbackConfigXmlUrl();
+        if (configurationUrlString == null) {
+            throw new IllegalStateException("LOGBack XML configuration file not specified");
+        }
+
+        return new URL(configurationUrlString);
     }
 
     @Override
@@ -41,5 +70,20 @@ public class LogbackImpl implements Logback {
 
     public Logger getLogger() {
         return logger;
+    }
+
+    public boolean refresh() throws Exception {
+        if (loggerSha == null) {
+            return false;
+        }
+
+        URL configurationUrl = getConfigurationURL();
+        URLSha latestSha1 = new URLSha(getConfigurationURL());
+        if (!latestSha1.equals(loggerSha)) {
+            initLogger(configurationUrl, loggerName);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackUtil.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackUtil.java
@@ -1,0 +1,44 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.spi.JoranException;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class LogbackUtil {
+    private static final String STATISTICS_GATHERER_LOGGER = "statistics-gatherer";
+    private static Logger logger;
+
+    private static Logger getLogger(String loggerName) {
+        LoggerContext loggerContext = new LoggerContext();
+        ContextInitializer contextInitializer = new ContextInitializer(loggerContext);
+        try {
+            String configurationUrlString = PropertyLoader.getLogbackConfigXmlUrl();
+            if (configurationUrlString == null) {
+                throw new IllegalStateException("LOGBack XML configuration file not specified");
+            }
+
+            URL configurationUrl = new URL(configurationUrlString);
+            contextInitializer.configureByResource(configurationUrl);
+            return loggerContext.getLogger(loggerName);
+        } catch (JoranException e) {
+            throw new RuntimeException("Unable to configure logger", e);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Unable to find LOGBack XML configuration", e);
+        }
+    }
+
+    public static void info(Object object) {
+        if (PropertyLoader.getShouldSendToLogback()) {
+            if(logger == null) {
+                synchronized (LogbackUtil.class) {
+                    logger = getLogger(STATISTICS_GATHERER_LOGGER);
+                }
+            }
+            logger.info(JSONUtil.convertToJson(object));
+        }
+    }
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
@@ -1,5 +1,6 @@
 package org.jenkins.plugins.statistics.gatherer.util;
 
+import com.google.common.base.Strings;
 import hudson.EnvVars;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
@@ -54,16 +55,29 @@ public class PropertyLoader {
         for (EnvironmentVariablesNodeProperty environmentVariablesNodeProperty : properties) {
             environmentVariables.putAll(environmentVariablesNodeProperty.getEnvVars());
         }
-        final String value = environmentVariables.get(key);
-        if (value == null || value.isEmpty()) {
-            return getResourceBundleProperty(key);
+        String value = environmentVariables.get(key);
+        if (!Strings.isNullOrEmpty(value)) {
+            return value;
         }
-        return value;
+        value = environmentVariables.get(key.toLowerCase());
+        if (!Strings.isNullOrEmpty(value)) {
+            return value;
+        }
+
+        value = getResourceBundleProperty(key);
+        if (!Strings.isNullOrEmpty(value)) {
+            return value;
+        }
+        return getResourceBundleProperty(key.toLowerCase());
     }
 
     public static String getEnvironmentProperty(
             final String key) {
         return getInstance().getProperty(key);
+    }
+
+    public static boolean isTrue(String value) {
+        return value != null ? value.toLowerCase().equals("true") : false;
     }
 
     public static String getQueueEndPoint() {
@@ -153,7 +167,7 @@ public class PropertyLoader {
             return queueInfo;
         }
         String queueInfoEnv = getEnvironmentProperty("statistics.endpoint.queueInfo");
-        return "true".equals(queueInfoEnv);
+        return isTrue(queueInfoEnv);
     }
 
     public static Boolean getBuildInfo() {
@@ -161,8 +175,7 @@ public class PropertyLoader {
         if (buildInfo != null) {
             return buildInfo;
         }
-        String buildInfoEnv = getEnvironmentProperty("statistics.endpoint.buildInfo");
-        return "true".equals(buildInfoEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.buildInfo"));
     }
 
     public static Boolean getProjectInfo() {
@@ -170,8 +183,7 @@ public class PropertyLoader {
         if (projectInfo != null) {
             return projectInfo;
         }
-        String projectInfoEnv = getEnvironmentProperty("statistics.endpoint.projectInfo");
-        return "true".equals(projectInfoEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.projectInfo"));
     }
 
     public static Boolean getBuildStepInfo() {
@@ -179,8 +191,7 @@ public class PropertyLoader {
         if (buildStepInfo != null) {
             return buildStepInfo;
         }
-        String buildStepInfoEnv = getEnvironmentProperty("statistics.endpoint.buildStepInfo");
-        return "true".equals(buildStepInfoEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.buildStepInfo"));
     }
 
     public static Boolean getScmCheckoutInfo() {
@@ -188,8 +199,7 @@ public class PropertyLoader {
         if (scmCheckoutInfo != null) {
             return scmCheckoutInfo;
         }
-        String scmCheckoutInfoEnv = getEnvironmentProperty("statistics.endpoint.scmCheckoutInfo");
-        return "true".equals(scmCheckoutInfoEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.scmCheckoutInfo"));
     }
 
     public static Boolean getShouldSendApiHttpRequests() {
@@ -197,8 +207,7 @@ public class PropertyLoader {
         if (shouldSendApiHttpRequests != null) {
             return shouldSendApiHttpRequests;
         }
-        String shouldSendApiHttpRequestsInfoEnv = getEnvironmentProperty("statistics.endpoint.shouldSendApiHttpRequests");
-        return "true".equals(shouldSendApiHttpRequestsInfoEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.shouldSendApiHttpRequests"));
     }
 
     public static Boolean getShouldPublishToAwsSnsQueue() {
@@ -206,7 +215,22 @@ public class PropertyLoader {
         if (shouldPublishToAwsSnsQueue != null) {
             return shouldPublishToAwsSnsQueue;
         }
-        String shouldPublishToAwsSnsQueueEnv = getEnvironmentProperty("statistics.endpoint.shouldPublishToAwsSnsQueue");
-        return "true".equals(shouldPublishToAwsSnsQueueEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.shouldPublishToAwsSnsQueue"));
+    }
+
+    public static boolean getShouldSendToLogback() {
+        Boolean shouldSendToLogback = StatisticsConfiguration.get().getShouldSendToLogback();
+        if (shouldSendToLogback != null) {
+            return shouldSendToLogback;
+        }
+        return isTrue(getEnvironmentProperty("statistics.endpoint.shouldSendToLogback"));
+    }
+
+    public static String getLogbackConfigXmlUrl() {
+        String logbackConfigXmlUrlString = StatisticsConfiguration.get().getLogbackConfigXmlUrl();
+        if (logbackConfigXmlUrlString == null) {
+            logbackConfigXmlUrlString = getEnvironmentProperty("statistics.endpoint.logbackConfigXmlUrl");
+        }
+        return logbackConfigXmlUrlString;
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
@@ -23,7 +23,7 @@ public class PropertyLoader {
 
     public static final synchronized PropertyLoader getInstance() {
         if (instance == null) {
-            instance = new PropertyLoader();
+            setInstance(new PropertyLoader());
         }
         return instance;
     }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
@@ -10,6 +10,7 @@ import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.StatisticsConfiguration;
 
 import java.util.List;
+import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 
@@ -35,7 +36,11 @@ public class PropertyLoader {
     }
 
     protected String getResourceBundleProperty(String keyProperty) {
-        return resourceBundle.getString(keyProperty);
+        try {
+            return resourceBundle.getString(keyProperty);
+        } catch (MissingResourceException e) {
+            return null;
+        }
     }
 
     public String getProperty(

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
@@ -111,6 +111,42 @@ public class PropertyLoader {
         return endPoint == null ? "" : endPoint;
     }
 
+    public static String getAwsRegion() {
+        String awsRegion = StatisticsConfiguration.get().getAwsRegion();
+        if (awsRegion != null && !awsRegion.isEmpty()) {
+            return awsRegion;
+        }
+        awsRegion = getEnvironmentProperty("statistics.endpoint.awsRegion");
+        return awsRegion == null ? "" : awsRegion;
+    }
+
+    public static String getAwsAccessKey() {
+        String awsAccessKey = StatisticsConfiguration.get().getAwsAccessKey();
+        if (awsAccessKey != null && !awsAccessKey.isEmpty()) {
+            return awsAccessKey;
+        }
+        awsAccessKey = getEnvironmentProperty("statistics.endpoint.awsAccessKey");
+        return awsAccessKey == null ? "" : awsAccessKey;
+    }
+
+    public static String getAwsSecretKey() {
+        String awsSecretKey = StatisticsConfiguration.get().getAwsSecretKey();
+        if (awsSecretKey != null && !awsSecretKey.isEmpty()) {
+            return awsSecretKey;
+        }
+        awsSecretKey = getEnvironmentProperty("statistics.endpoint.awsSecretKey");
+        return awsSecretKey == null ? "" : awsSecretKey;
+    }
+
+    public static String getSnsArn() {
+        String snsArn = StatisticsConfiguration.get().getSnsArn();
+        if (snsArn != null && !snsArn.isEmpty()) {
+            return snsArn;
+        }
+        snsArn = getEnvironmentProperty("statistics.endpoint.snsArn");
+        return snsArn == null ? "" : snsArn;
+    }
+
     public static Boolean getQueueInfo() {
         Boolean queueInfo = StatisticsConfiguration.get().getQueueInfo();
         if (queueInfo != null) {
@@ -154,5 +190,23 @@ public class PropertyLoader {
         }
         String scmCheckoutInfoEnv = getEnvironmentProperty("statistics.endpoint.scmCheckoutInfo");
         return "true".equals(scmCheckoutInfoEnv);
+    }
+
+    public static Boolean getShouldSendApiHttpRequests() {
+        Boolean shouldSendApiHttpRequests = StatisticsConfiguration.get().getShouldSendApiHttpRequests();
+        if (shouldSendApiHttpRequests != null) {
+            return shouldSendApiHttpRequests;
+        }
+        String shouldSendApiHttpRequestsInfoEnv = getEnvironmentProperty("statistics.endpoint.shouldSendApiHttpRequests");
+        return "true".equals(shouldSendApiHttpRequestsInfoEnv);
+    }
+
+    public static Boolean getShouldPublishToAwsSnsQueue() {
+        Boolean shouldPublishToAwsSnsQueue = StatisticsConfiguration.get().getShouldPublishToAwsSnsQueue();
+        if (shouldPublishToAwsSnsQueue != null) {
+            return shouldPublishToAwsSnsQueue;
+        }
+        String shouldPublishToAwsSnsQueueEnv = getEnvironmentProperty("statistics.endpoint.shouldPublishToAwsSnsQueue");
+        return "true".equals(shouldPublishToAwsSnsQueueEnv);
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
@@ -138,13 +138,13 @@ public class PropertyLoader {
         return awsSecretKey == null ? "" : awsSecretKey;
     }
 
-    public static String getSnsArn() {
-        String snsArn = StatisticsConfiguration.get().getSnsArn();
-        if (snsArn != null && !snsArn.isEmpty()) {
-            return snsArn;
+    public static String getSnsTopicArn() {
+        String snsTopicArn = StatisticsConfiguration.get().getSnsTopicArn();
+        if (snsTopicArn != null && !snsTopicArn.isEmpty()) {
+            return snsTopicArn;
         }
-        snsArn = getEnvironmentProperty("statistics.endpoint.snsArn");
-        return snsArn == null ? "" : snsArn;
+        snsTopicArn = getEnvironmentProperty("statistics.endpoint.snsTopicArn");
+        return snsTopicArn == null ? "" : snsTopicArn;
     }
 
     public static Boolean getQueueInfo() {

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtil.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtil.java
@@ -23,27 +23,31 @@ public class RestClientUtil {
 
     public static void postToService(final String url, Object object) {
         if (PropertyLoader.getShouldSendApiHttpRequests()) {
-            String jsonToPost = JSONUtil.convertToJson(object);
-            Unirest.post(url)
-                    .header(ACCEPT, APPLICATION_JSON)
-                    .header(CONTENT_TYPE, APPLICATION_JSON)
-                    .body(jsonToPost)
-                    .asJsonAsync(new Callback<JsonNode>() {
+            try {
+                String jsonToPost = JSONUtil.convertToJson(object);
+                Unirest.post(url)
+                        .header(ACCEPT, APPLICATION_JSON)
+                        .header(CONTENT_TYPE, APPLICATION_JSON)
+                        .body(jsonToPost)
+                        .asJsonAsync(new Callback<JsonNode>() {
 
-                        public void failed(UnirestException e) {
-                            LOGGER.log(Level.WARNING, "The request for url " + url + " has failed.", e);
-                        }
+                            public void failed(UnirestException e) {
+                                LOGGER.log(Level.WARNING, "The request for url " + url + " has failed.", e);
+                            }
 
-                        public void completed(HttpResponse<JsonNode> response) {
-                            int responseCode = response.getStatus();
-                            LOGGER.log(Level.INFO, "The request for url " + url + " completed with status " + responseCode);
-                        }
+                            public void completed(HttpResponse<JsonNode> response) {
+                                int responseCode = response.getStatus();
+                                LOGGER.log(Level.INFO, "The request for url " + url + " completed with status " + responseCode);
+                            }
 
-                        public void cancelled() {
-                            LOGGER.log(Level.INFO, "The request for url " + url + " has been cancelled");
-                        }
+                            public void cancelled() {
+                                LOGGER.log(Level.INFO, "The request for url " + url + " has been cancelled");
+                            }
 
-                    });
+                        });
+            } catch (Throwable e) {
+                LOGGER.log(Level.WARNING, "Unable to post event to url " + url, e);
+            }
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtil.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtil.java
@@ -12,8 +12,7 @@ import java.util.logging.Logger;
 
 public class RestClientUtil {
 
-    private static final Logger LOGGER = Logger.getLogger(
-            RestClientUtil.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(RestClientUtil.class.getName());
     public static final String APPLICATION_JSON = "application/json";
     public static final String ACCEPT = "accept";
     public static final String CONTENT_TYPE = "Content-Type";
@@ -23,27 +22,29 @@ public class RestClientUtil {
     }
 
     public static void postToService(final String url, Object object) {
-        String jsonToPost = JSONUtil.convertToJson(object);
-        Unirest.post(url)
-                .header(ACCEPT, APPLICATION_JSON)
-                .header(CONTENT_TYPE, APPLICATION_JSON)
-                .body(jsonToPost)
-                .asJsonAsync(new Callback<JsonNode>() {
+        if (PropertyLoader.getShouldSendApiHttpRequests()) {
+            String jsonToPost = JSONUtil.convertToJson(object);
+            Unirest.post(url)
+                    .header(ACCEPT, APPLICATION_JSON)
+                    .header(CONTENT_TYPE, APPLICATION_JSON)
+                    .body(jsonToPost)
+                    .asJsonAsync(new Callback<JsonNode>() {
 
-                    public void failed(UnirestException e) {
-                        LOGGER.log(Level.WARNING, "The request for url " + url + " has failed.", e);
-                    }
+                        public void failed(UnirestException e) {
+                            LOGGER.log(Level.WARNING, "The request for url " + url + " has failed.", e);
+                        }
 
-                    public void completed(HttpResponse<JsonNode> response) {
-                        int responseCode = response.getStatus();
-                        LOGGER.log(Level.INFO, "The request for url " + url + " completed with status " + responseCode);
-                    }
+                        public void completed(HttpResponse<JsonNode> response) {
+                            int responseCode = response.getStatus();
+                            LOGGER.log(Level.INFO, "The request for url " + url + " completed with status " + responseCode);
+                        }
 
-                    public void cancelled() {
-                        LOGGER.log(Level.INFO, "The request for url " + url + " has been cancelled");
-                    }
+                        public void cancelled() {
+                            LOGGER.log(Level.INFO, "The request for url " + url + " has been cancelled");
+                        }
 
-                });
+                    });
+        }
     }
 
     public static JSONObject getJson(final String url) {

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtil.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtil.java
@@ -18,7 +18,7 @@ public class RestClientUtil {
     public static final String ACCEPT = "accept";
     public static final String CONTENT_TYPE = "Content-Type";
 
-    private RestClientUtil() {
+    protected RestClientUtil() {
         throw new IllegalAccessError("Utility class");
     }
 
@@ -55,7 +55,7 @@ public class RestClientUtil {
             return response.getBody().getObject();
         }
         catch (UnirestException e){
-            LOGGER.log(Level.WARNING, "Json called have failed in unirest.", e);
+            LOGGER.log(Level.WARNING, "Json call have failed in unirest.", e);
         }
         return null;
     }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/SnsClientUtil.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/SnsClientUtil.java
@@ -1,0 +1,62 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.handlers.AsyncHandler;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.RegionUtils;
+import com.amazonaws.services.sns.AmazonSNSAsyncClient;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Created by alexgandy on 1/12/17.
+ */
+public class SnsClientUtil {
+
+    private static final Logger LOGGER = Logger.getLogger(AmazonSNSAsyncClient.class.getName());
+    private static AmazonSNSAsyncClient snsClient;
+
+    public static AmazonSNSAsyncClient getSnsClient() {
+        if (snsClient == null) {
+            BasicAWSCredentials awsCredentials = new BasicAWSCredentials(PropertyLoader.getAwsAccessKey(), PropertyLoader.getAwsSecretKey());
+            snsClient = new AmazonSNSAsyncClient(awsCredentials);
+
+            Region snsRegion = RegionUtils.getRegion(PropertyLoader.getAwsRegion());
+            snsClient.setRegion(snsRegion);
+        }
+
+        return snsClient;
+    }
+
+    public static void publishToSns(Object object) {
+        if (PropertyLoader.getShouldPublishToAwsSnsQueue()) {
+            String jsonToPublish = JSONUtil.convertToJson(object);
+
+            PublishRequest pr = new PublishRequest();
+            String snsTopicArn = PropertyLoader.getSnsTopicArn();
+
+            if (snsTopicArn == null || snsTopicArn.isEmpty()) {
+                LOGGER.log(Level.WARNING, "Missing required SNS Topic ARN");
+                return;
+            }
+
+            pr.setTopicArn(PropertyLoader.getSnsTopicArn());
+            pr.setMessage(jsonToPublish);
+
+            AmazonSNSAsyncClient client = getSnsClient();
+            client.publishAsync(pr, new AsyncHandler<PublishRequest, PublishResult>() {
+                @Override
+                public void onError(Exception e) {
+                    LOGGER.log(Level.WARNING, e.getMessage(), e);
+                }
+
+                @Override
+                public void onSuccess(PublishRequest request, PublishResult publishResult) {
+                    LOGGER.log(Level.INFO, "Message ID: " + publishResult.getMessageId() + " successfully published");
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/URLSha.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/URLSha.java
@@ -1,0 +1,29 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Objects;
+
+public class URLSha {
+    private String value;
+
+    public URLSha(URL configurationUrl) throws IOException {
+        try (InputStream is = configurationUrl.openStream()) {
+            value = DigestUtils.sha1Hex(is);
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return (obj instanceof URLSha) ? Objects.equals(this.value, ((URLSha) obj).value) : false;
+    }
+
+    @Override
+    public String toString() {
+        return "{sha1}" + value;
+    }
+}

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
@@ -4,19 +4,19 @@ def f=namespace(lib.FormTagLib)
 
 f.section(title:_("Statistics Gatherer")) {
     f.entry(title:_("Queue URL"), field:"queueUrl") {
-        f.textbox(default: "")
+        f.textbox()
     }
     f.entry(title:_("Build URL"), field:"buildUrl") {
-        f.textbox(default: "")
+        f.textbox()
     }
     f.entry(title:_("Project URL"), field:"projectUrl") {
-        f.textbox(default: "")
+        f.textbox()
     }
     f.entry(title:_("BuildSteps URL"), field:"buildStepUrl") {
-        f.textbox(default: "")
+        f.textbox()
     }
     f.entry(title:_("ScmCheckoutInfo URL"), field:"scmCheckoutUrl") {
-        f.textbox(default: "")
+        f.textbox()
     }
 
     f.entry(title:_("Send Queue Info"), field:"queueInfo") {
@@ -58,7 +58,7 @@ f.section(title:_("Statistics Gatherer")) {
         }
 
         f.entry(title:_("Enable HTTP publishing?"), field:"shouldSendApiHttpRequests") {
-            f.checkbox(default: instance.shouldSendApiHttpRequests == null ? true : instance.shouldSendApiHttpRequests.equals(true));
+            f.checkbox(default: instance.shouldSendApiHttpRequests == null ? false : instance.shouldSendApiHttpRequests.equals(true));
         }
     }
 }

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
@@ -4,19 +4,19 @@ def f=namespace(lib.FormTagLib)
 
 f.section(title:_("Statistics Gatherer")) {
     f.entry(title:_("Queue URL"), field:"queueUrl") {
-        f.textbox(default: "http://ci.mycompany.com/api/queue")
+        f.textbox(default: "")
     }
     f.entry(title:_("Build URL"), field:"buildUrl") {
-        f.textbox(default: "http://ci.mycompany.com/api/build")
+        f.textbox(default: "")
     }
     f.entry(title:_("Project URL"), field:"projectUrl") {
-        f.textbox(default: "http://ci.mycompany.com/api/projects")
+        f.textbox(default: "")
     }
     f.entry(title:_("BuildSteps URL"), field:"buildStepUrl") {
-        f.textbox(default: "http://ci.mycompany.com/api/step")
+        f.textbox(default: "")
     }
     f.entry(title:_("ScmCheckoutInfo URL"), field:"scmCheckoutUrl") {
-        f.textbox(default: "http://ci.mycompany.com/api/scm")
+        f.textbox(default: "")
     }
 
     f.entry(title:_("Send Queue Info"), field:"queueInfo") {

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
@@ -13,10 +13,10 @@ f.section(title:_("Statistics Gatherer")) {
         f.textbox(default: "http://ci.mycompany.com/api/projects")
     }
     f.entry(title:_("BuildSteps URL"), field:"buildStepUrl") {
-        f.textbox(default: "http://ci.mycompany.com/api//step")
+        f.textbox(default: "http://ci.mycompany.com/api/step")
     }
     f.entry(title:_("ScmCheckoutInfo URL"), field:"scmCheckoutUrl") {
-        f.textbox(default: "http://ci.mycompany.com/api//scm")
+        f.textbox(default: "http://ci.mycompany.com/api/scm")
     }
 
     f.entry(title:_("Send Queue Info"), field:"queueInfo") {
@@ -57,8 +57,8 @@ f.section(title:_("Statistics Gatherer")) {
             f.textbox()
         }
 
-        f.entry(title:_("Disable API HTTP requests? (Only use SNS?)"), field:"shouldSendApiHttpRequests") {
-            f.checkbox(default: instance.shouldSendApiHttpRequests == null ? false : instance.shouldSendApiHttpRequests.equals(true));
+        f.entry(title:_("Enable HTTP publishing?"), field:"shouldSendApiHttpRequests") {
+            f.checkbox(default: instance.shouldSendApiHttpRequests == null ? true : instance.shouldSendApiHttpRequests.equals(true));
         }
     }
 }

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
@@ -34,4 +34,31 @@ f.section(title:_("Statistics Gatherer")) {
     f.entry(title:_("Send Scm Checkout Info"), field:"scmCheckoutInfo") {
         f.checkbox(default: true)
     }
+
+    f.advanced(title: _("Advanced Settings")) {
+
+        f.entry(title:_("Publish to Amazon SNS Queue"), field:"shouldPublishToAwsSnsQueue") {
+            f.checkbox(default: instance.shouldPublishToAwsSnsQueue == null ? false : instance.shouldPublishToAwsSnsQueue.equals(true));
+        }
+
+        f.entry(title:_("AWS Access Key"), field:"awsAccessKey") {
+            f.textbox()
+        }
+
+        f.entry(title:_("AWS Secret Key"), field:"awsSecretKey") {
+            f.textbox()
+        }
+
+        f.entry(title:_("AWS Region"), field:"awsRegion") {
+            f.textbox()
+        }
+
+        f.entry(title:_("SNS ARN"), field:"snsArn") {
+            f.textbox()
+        }
+
+        f.entry(title:_("Disable API HTTP requests? (Only use SNS?)"), field:"shouldSendApiHttpRequests") {
+            f.checkbox(default: instance.shouldSendApiHttpRequests == null ? false : instance.shouldSendApiHttpRequests.equals(true));
+        }
+    }
 }

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
@@ -60,5 +60,13 @@ f.section(title:_("Statistics Gatherer")) {
         f.entry(title:_("Enable HTTP publishing?"), field:"shouldSendApiHttpRequests") {
             f.checkbox(default: instance.shouldSendApiHttpRequests == null ? false : instance.shouldSendApiHttpRequests.equals(true));
         }
+
+        f.entry(title:_("Enable publish of events to LOGBack"), field:"shouldSendToLogback") {
+            f.checkbox()
+        }
+
+        f.entry(title:_("LOGBack XML configuration URL"), field:"logbackConfigXmlUrl") {
+            f.textbox()
+        }
     }
 }

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
@@ -49,11 +49,11 @@ f.section(title:_("Statistics Gatherer")) {
             f.textbox()
         }
 
-        f.entry(title:_("AWS Region"), field:"awsRegion") {
+        f.entry(title:_("SNS Topic ARN"), field:"snsTopicArn") {
             f.textbox()
         }
 
-        f.entry(title:_("SNS ARN"), field:"snsArn") {
+        f.entry(title:_("AWS Region"), field:"awsRegion") {
             f.textbox()
         }
 

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-logbackConfigXmlUrl.html
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-logbackConfigXmlUrl.html
@@ -1,0 +1,3 @@
+<div>
+    URL of the <a href="https://logback.qos.ch/manual/configuration.html" target="_blank">LOGBack XML</a> configuration file<br/>
+</div>

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-shouldSendToLogback.html
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-shouldSendToLogback.html
@@ -1,0 +1,3 @@
+<div>
+    Allow to push events to a <a href="https://logback.qos.ch/manual/appenders.html"  target="_blank">LOGBack Appender</a><br/>
+</div>

--- a/src/main/resources/statistics.properties
+++ b/src/main/resources/statistics.properties
@@ -8,3 +8,6 @@ statistics.endpoint.buildInfo=true
 statistics.endpoint.projectInfo=true
 statistics.endpoint.buildStepInfo=true
 statistics.endpoint.scmCheckoutInfo=true
+statistics.endpoint.awsRegion=us-east-1
+statistics.endpoint.shouldSendApiHttpRequests=true
+statistics.endpoint.shouldPublishToAwsSnsQueue=false

--- a/src/main/resources/statistics.properties
+++ b/src/main/resources/statistics.properties
@@ -1,13 +1,8 @@
-statistics.endpoint.queueUrl=http://ci.mycompany.com/api/queue
-statistics.endpoint.buildUrl=http://ci.mycompany.com/api/build
-statistics.endpoint.projectUrl=http://cistats.mycompany.com/api/projects
-statistics.endpoint.buildStepUrl=http://ci.mycompany.com/api/step
-statistics.endpoint.scmCheckoutUrl=http://ci.mycompany.com/api/scm
 statistics.endpoint.queueInfo=true
 statistics.endpoint.buildInfo=true
 statistics.endpoint.projectInfo=true
 statistics.endpoint.buildStepInfo=true
 statistics.endpoint.scmCheckoutInfo=true
 statistics.endpoint.awsRegion=us-east-1
-statistics.endpoint.shouldSendApiHttpRequests=true
+statistics.endpoint.shouldSendApiHttpRequests=false
 statistics.endpoint.shouldPublishToAwsSnsQueue=false

--- a/src/main/resources/statistics.properties
+++ b/src/main/resources/statistics.properties
@@ -6,3 +6,4 @@ statistics.endpoint.scmCheckoutInfo=true
 statistics.endpoint.awsRegion=us-east-1
 statistics.endpoint.shouldSendApiHttpRequests=false
 statistics.endpoint.shouldPublishToAwsSnsQueue=false
+statistics.endpoint.shouldSendToLogback=false

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListenerTest.java
@@ -4,6 +4,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.tasks.BuildStep;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
 import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
@@ -27,7 +28,7 @@ import static org.mockito.Matchers.anyString;
  */
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({PropertyLoader.class, RestClientUtil.class, SnsClientUtil.class})
+@PrepareForTest({PropertyLoader.class, RestClientUtil.class, SnsClientUtil.class, LogbackUtil.class})
 public class BuildStepStatsListenerTest {
 
     private BuildStepStatsListener listener;
@@ -57,7 +58,6 @@ public class BuildStepStatsListenerTest {
         BuildStepStats buildStepStats = buildStepStatsArgumentCaptor.getValue();
         assertEquals("aUrl", buildStepStats.getBuildUrl());
         assertEquals(new Date(0), buildStepStats.getEndTime());
-
     }
 
     @Test

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListenerTest.java
@@ -1,0 +1,108 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.tasks.BuildStep;
+import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
+import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
+import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+
+
+/**
+ * Created by mcharron on 2016-07-27.
+ */
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertyLoader.class, RestClientUtil.class})
+public class BuildStepStatsListenerTest {
+
+    private BuildStepStatsListener listener;
+
+    @Before
+    public void setup(){
+        listener = new BuildStepStatsListener();
+    }
+
+    @Test
+    public void givenBuildAndBuildInfoTrue_whenStarted_thenPost(){
+        PowerMockito.mockStatic(PropertyLoader.class);
+        Mockito.when(PropertyLoader.getBuildStepInfo()).thenReturn(true);
+        Mockito.when(PropertyLoader.getBuildEndPoint()).thenReturn("");
+        AbstractBuild build = Mockito.mock(AbstractBuild.class);
+        Mockito.when(build.getUrl()).thenReturn("aUrl");
+        BuildStep steps = Mockito.mock(BuildStep.class);
+        BuildListener buildListener = Mockito.mock(BuildListener.class);
+        PowerMockito.mockStatic(RestClientUtil.class);
+        ArgumentCaptor<BuildStepStats> buildStepStatsArgumentCaptor =
+                ArgumentCaptor.forClass(BuildStepStats.class);
+        listener.started(build, steps, buildListener);
+
+        PowerMockito.verifyStatic();
+        RestClientUtil.postToService(anyString(), buildStepStatsArgumentCaptor.capture());
+
+        BuildStepStats buildStepStats = buildStepStatsArgumentCaptor.getValue();
+        assertEquals("aUrl", buildStepStats.getBuildUrl());
+        assertEquals(new Date(0), buildStepStats.getEndTime());
+
+    }
+
+    @Test
+    public void givenBuildAndBuildInfoFalse_whenStarted_thenDoNotPost(){
+        PowerMockito.mockStatic(PropertyLoader.class);
+        Mockito.when(PropertyLoader.getBuildStepInfo()).thenReturn(false);
+        AbstractBuild build = Mockito.mock(AbstractBuild.class);
+        BuildStep steps = Mockito.mock(BuildStep.class);
+        BuildListener buildListener = Mockito.mock(BuildListener.class);
+        listener.started(build, steps, buildListener);
+        PowerMockito.mockStatic(RestClientUtil.class);
+        PowerMockito.verifyStatic(Mockito.never());
+    }
+
+    @Test
+    public void givenBuildAndBuildInfoTrue_whenFinished_thenPost(){
+        PowerMockito.mockStatic(PropertyLoader.class);
+        Mockito.when(PropertyLoader.getBuildStepInfo()).thenReturn(true);
+        Mockito.when(PropertyLoader.getBuildEndPoint()).thenReturn("");
+        AbstractBuild build = Mockito.mock(AbstractBuild.class);
+        Mockito.when(build.getUrl()).thenReturn("aUrl");
+        BuildStep steps = Mockito.mock(BuildStep.class);
+        BuildListener buildListener = Mockito.mock(BuildListener.class);
+        PowerMockito.mockStatic(RestClientUtil.class);
+        ArgumentCaptor<BuildStepStats> buildStepStatsArgumentCaptor =
+                ArgumentCaptor.forClass(BuildStepStats.class);
+        listener.finished(build, steps, buildListener, true);
+
+        PowerMockito.verifyStatic();
+        RestClientUtil.postToService(anyString(), buildStepStatsArgumentCaptor.capture());
+
+        BuildStepStats buildStepStats = buildStepStatsArgumentCaptor.getValue();
+        assertEquals("aUrl", buildStepStats.getBuildUrl());
+        assertEquals(new Date(0), buildStepStats.getStartTime());
+
+    }
+
+    @Test
+    public void givenBuildAndBuildInfoFalse_whenFinished_thenDoNotPost(){
+        PowerMockito.mockStatic(PropertyLoader.class);
+        Mockito.when(PropertyLoader.getBuildStepInfo()).thenReturn(false);
+        AbstractBuild build = Mockito.mock(AbstractBuild.class);
+        BuildStep steps = Mockito.mock(BuildStep.class);
+        BuildListener buildListener = Mockito.mock(BuildListener.class);
+        listener.finished(build, steps, buildListener, true);
+        PowerMockito.mockStatic(RestClientUtil.class);
+        PowerMockito.verifyStatic(Mockito.never());
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListenerTest.java
@@ -1,0 +1,86 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.model.FreeStyleProject;
+import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
+import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
+import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertyLoader.class, RestClientUtil.class, LogbackUtil.class})
+@PowerMockIgnore({"javax.crypto.*"})
+public class ItemStatsListenerTest {
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    private ItemStatsListener listener;
+
+    @Before
+    public void setup() {
+        listener = new ItemStatsListener();
+        mockStatic(PropertyLoader.class);
+    }
+
+    @Test
+    public void whenItemCredated_thenPost() throws Exception {
+        mockStatic(RestClientUtil.class);
+        when(PropertyLoader.getProjectInfo()).thenReturn(true);
+
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+
+        verifyStatic();
+        ArgumentCaptor<JobStats> captor =
+                ArgumentCaptor.forClass(JobStats.class);
+        RestClientUtil.postToService(anyString(), captor.capture());
+        JobStats jobStats = captor.getValue();
+
+        assertThat(jobStats.getName(), startsWith("test"));
+        assertThat(jobStats.getJobUrl(), startsWith("job/test"));
+        assertThat(jobStats.getStatus(), equalTo("ACTIVE"));
+    }
+
+    @Test
+    public void whenItemDeleted_thenPost() throws Exception {
+        mockStatic(RestClientUtil.class);
+        when(PropertyLoader.getProjectInfo()).thenReturn(true);
+
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+        project.delete();
+
+        verifyStatic(times(3));
+        ArgumentCaptor<JobStats> captor =
+                ArgumentCaptor.forClass(JobStats.class);
+        RestClientUtil.postToService(anyString(), captor.capture());
+        List<JobStats> jobStats = captor.getAllValues();
+
+        JobStats disabled = jobStats.get(1);
+        JobStats deleted = jobStats.get(2);
+
+        assertThat(disabled.getName(), startsWith("test"));
+        assertThat(disabled.getJobUrl(), startsWith("job/test"));
+        assertThat(disabled.getStatus(), equalTo("DISABLED"));
+
+        assertThat(deleted.getName(), startsWith("test"));
+        assertThat(deleted.getJobUrl(), startsWith("job/test"));
+        assertThat(deleted.getStatus(), equalTo("DELETED"));
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListenerTest.java
@@ -1,0 +1,72 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.model.Action;
+import hudson.model.Queue;
+import org.jenkins.plugins.statistics.gatherer.model.build.BuildStats;
+import org.jenkins.plugins.statistics.gatherer.model.queue.QueueStats;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
+import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
+import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertyLoader.class, RestClientUtil.class, SnsClientUtil.class, LogbackUtil.class})
+@PowerMockIgnore({"javax.crypto.*"})
+public class QueueStatsListenerTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private QueueStatsListener listener;
+
+    @Before
+    public void setup(){
+        listener = new QueueStatsListener();
+    }
+
+    @Test
+    public void givenOnLeftNoOutcome_thenPost() throws IOException {
+        mockStatic(RestClientUtil.class);
+        mockStatic(PropertyLoader.class);
+        when(PropertyLoader.getQueueInfo()).thenReturn(true);
+        when(PropertyLoader.getQueueEndPoint()).thenReturn("http://localhost");
+
+        Queue.Task project = j.createFreeStyleProject("test");
+        List<Action> actions = Collections.emptyList();
+        Queue.Item item = new Queue.WaitingItem(Calendar.getInstance(), project, actions);
+        Queue.LeftItem leftItem = new Queue.LeftItem(item);
+
+        listener.onLeft(leftItem);
+
+        verifyStatic(RestClientUtil.class, times(1));
+        ArgumentCaptor<QueueStats> captor =
+                ArgumentCaptor.forClass(QueueStats.class);
+        RestClientUtil.postToService(anyString(), captor.capture());
+        QueueStats queueStats = captor.getAllValues().get(0);
+
+        assertThat(queueStats.getContextId(), is(equalTo(0)));
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListenerTest.java
@@ -1,0 +1,97 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.model.Build;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.TaskListener;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.tasks.Shell;
+import jenkins.model.Jenkins;
+import org.jenkins.plugins.statistics.gatherer.model.build.BuildStats;
+import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
+import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.isNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.hamcrest.CoreMatchers.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertyLoader.class, RestClientUtil.class})
+@PowerMockIgnore({"javax.crypto.*"})
+public class RunStatsListenerTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private RunStatsListener listener;
+    private TaskListener soutListener = new SoutTaskListener();
+
+    @Before
+    public void setup() {
+        listener = new RunStatsListener();
+        mockStatic(PropertyLoader.class);
+        mockStatic(RestClientUtil.class);
+    }
+
+    @Test
+    public void givenRunWithBuildInfoTrue_whenStarted_thenPostTwice() throws Exception {
+        when(PropertyLoader.getBuildInfo()).thenReturn(true);
+
+        Build<?, ?> build = triggerNewBuild().get();
+
+        verifyStatic(times(2));
+        ArgumentCaptor<BuildStats> captor =
+                ArgumentCaptor.forClass(BuildStats.class);
+        RestClientUtil.postToService(anyString(), captor.capture());
+        BuildStats buildStats = captor.getAllValues().get(0);
+
+        assertThat(buildStats.getResult(), is(equalTo("INPROGRESS")));
+        assertBuildInfoEqualsTo(buildStats, build);
+    }
+
+    @Test
+    public void givenRunWithBuildInfoTrue_whenCompleted_thenPost() throws Exception {
+        when(PropertyLoader.getBuildInfo()).thenReturn(true);
+
+        Build<?, ?> build = triggerNewBuild().get();
+
+        verifyStatic(times(2));
+        ArgumentCaptor<BuildStats> captor =
+                ArgumentCaptor.forClass(BuildStats.class);
+        RestClientUtil.postToService(anyString(), captor.capture());
+        BuildStats buildStats = captor.getAllValues().get(1);
+
+        assertThat(buildStats.getResult(), is(equalTo("SUCCESS")));
+        assertBuildInfoEqualsTo(buildStats, build);
+    }
+
+    private void assertBuildInfoEqualsTo(BuildStats buildStats, Build<?, ?> build) {
+        assertThat(buildStats.getBuildUrl(), is(build.getUrl()));
+        assertThat(buildStats.getStartTime(), is(notNullValue()));
+        assertThat(buildStats.getBuildCause(), is(notNullValue()));
+        assertThat(buildStats.getFullJobName(), is(build.getParent().getFullName()));
+        assertThat(buildStats.getJobName(), is(build.getParent().getName()));
+        assertThat(buildStats.getNumber(), is(build.getNumber()));
+    }
+
+    private QueueTaskFuture<FreeStyleBuild> triggerNewBuild() throws IOException {
+        FreeStyleProject project = j.createFreeStyleProject();
+        project.getBuildersList().add(new Shell("echo hello"));
+        return project.scheduleBuild2(0);
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListenerTest.java
@@ -1,0 +1,84 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.FilePath;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+import hudson.scm.SCM;
+import hudson.scm.SCMRevisionState;
+import hudson.tasks.BuildStep;
+import org.jenkins.plugins.statistics.gatherer.model.scm.ScmCheckoutInfo;
+import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
+import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
+import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+
+/**
+ * Created by mcharron on 2016-07-27.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertyLoader.class, RestClientUtil.class})
+public class ScmStatsListenerTest {
+
+    private ScmStatsListener listener;
+
+    @Before
+    public void setup(){
+        listener = new ScmStatsListener();
+    }
+
+    @Test
+    public void givenBuildAndBuildInfoTrue_whenStarted_thenPost(){
+        PowerMockito.mockStatic(PropertyLoader.class);
+        Mockito.when(PropertyLoader.getScmCheckoutInfo()).thenReturn(true);
+        Mockito.when(PropertyLoader.getScmCheckoutEndPoint()).thenReturn("");
+        AbstractBuild build = Mockito.mock(AbstractBuild.class);
+        Mockito.when(build.getUrl()).thenReturn("aUrl");
+        SCM scm = Mockito.mock(SCM.class);
+        FilePath filePath = new FilePath(Mockito.mock(VirtualChannel.class), "");
+        TaskListener taskListener = Mockito.mock(TaskListener.class);
+        File file = Mockito.mock(File.class);
+        SCMRevisionState scmRevisionState = Mockito.mock(SCMRevisionState.class);
+        PowerMockito.mockStatic(RestClientUtil.class);
+        ArgumentCaptor<ScmCheckoutInfo> scmCheckoutInfoArgumentCaptor =
+                ArgumentCaptor.forClass(ScmCheckoutInfo.class);
+        listener.onCheckout(build, scm, filePath, taskListener, file, scmRevisionState);
+
+        PowerMockito.verifyStatic();
+        RestClientUtil.postToService(anyString(), scmCheckoutInfoArgumentCaptor.capture());
+
+        ScmCheckoutInfo buildStepStats = scmCheckoutInfoArgumentCaptor.getValue();
+        assertEquals("aUrl", buildStepStats.getBuildUrl());
+        assertEquals(new Date(0), buildStepStats.getStartTime());
+
+    }
+
+    @Test
+    public void givenBuildAndBuildInfoFalse_whenStarted_thenDoNotPost(){
+        PowerMockito.mockStatic(PropertyLoader.class);
+        Mockito.when(PropertyLoader.getScmCheckoutInfo()).thenReturn(false);
+        AbstractBuild build = Mockito.mock(AbstractBuild.class);
+        SCM scm = Mockito.mock(SCM.class);
+        FilePath filePath = new FilePath(Mockito.mock(VirtualChannel.class), "");
+        TaskListener taskListener = Mockito.mock(TaskListener.class);
+        File file = Mockito.mock(File.class);
+        SCMRevisionState scmRevisionState = Mockito.mock(SCMRevisionState.class);
+        listener.onCheckout(build, scm, filePath, taskListener, file, scmRevisionState);
+        PowerMockito.mockStatic(RestClientUtil.class);
+        PowerMockito.verifyStatic(Mockito.never());
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListenerTest.java
@@ -12,6 +12,7 @@ import org.jenkins.plugins.statistics.gatherer.model.scm.ScmCheckoutInfo;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/ConstantsTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/ConstantsTest.java
@@ -1,0 +1,14 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import org.junit.Test;
+
+/**
+ * Created by mcharron on 2016-07-27.
+ */
+public class ConstantsTest {
+
+    @Test(expected=IllegalAccessError.class)
+    public void givenProtectedConstructor_whenNew_throwIllegalAccess(){
+        new Constants();
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/JSONUtilTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/JSONUtilTest.java
@@ -2,7 +2,10 @@ package org.jenkins.plugins.statistics.gatherer.util;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import org.jenkins.plugins.statistics.gatherer.model.build.SCMInfo;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -12,6 +15,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -37,15 +42,46 @@ public class JSONUtilTest {
         assertEquals(expectedJson, jsonString);
     }
 
-//    @Test(expected=JsonParseException.class)
-//    public void givenInvalidObject_whenToJson_thenThrows() throws IOException{
-//        testObject.setUrl("http://test.com");
-//        testObject.setBranch("blop");
-//        testObject.setCommit("blopie");
-//        ObjectMapper mapper = Mockito.mock(ObjectMapper.class);
-//        Mockito.doThrow(new JsonParseException(null, "error"))
-//                .when(mapper).writeValueAsString(Matchers.anyObject());
-//        JSONUtil.convertToJson(testObject);
-//
-//    }
+    @Test
+    public void givenInvalidObject_whenToJson_thenReturnEmptyJson(){
+        JSONObject object = new JSONObject();
+        String json = JSONUtil.convertToJson(object);
+        assertEquals("", json);
+    }
+
+    @Test
+    public void givenJsonArray_whenConvertToList_thenReturnList(){
+        JSONArray array = new JSONArray();
+        array.put("test");
+        List<String> result = JSONUtil.convertJsonArrayToList(array);
+        assertEquals(1, result.size());
+        assertEquals("test", result.get(0));
+    }
+
+    @Test
+    public void givenNull_whenConvertToList_thenReturnEmptyList(){
+        List<String> result = JSONUtil.convertJsonArrayToList(null);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void givenJsonObjectWithCategories_whenConvertBuildFailureToMap_thenReturnValidMap(){
+        JSONArray array = new JSONArray();
+        array.put("test");
+        JSONObject object = new JSONObject();
+        object.put("categories", array);
+        Map<String, Object> result = JSONUtil.convertBuildFailureToMap(object);
+        assertEquals(1, result.size());
+        assertEquals(1, ((List)result.get("categories")).size());
+        assertEquals("test", ((List)result.get("categories")).get(0));
+    }
+
+    @Test
+    public void givenJsonObjectWithoutCategories_whenConvertBuildFailureToMap_thenReturnValidMap(){
+        JSONObject object = new JSONObject();
+        object.put("stuff", "testString");
+        Map<String, Object> result = JSONUtil.convertBuildFailureToMap(object);
+        assertEquals(1, result.size());
+        assertEquals("testString", result.get("stuff"));
+    }
 }

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/JSONUtilTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/JSONUtilTest.java
@@ -84,4 +84,8 @@ public class JSONUtilTest {
         assertEquals(1, result.size());
         assertEquals("testString", result.get("stuff"));
     }
+    @Test(expected=IllegalAccessError.class)
+    public void givenProtectedConstructor_whenNew_throwIllegalAccess(){
+        new JSONUtil();
+    }
 }

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/JenkinsCausesTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/JenkinsCausesTest.java
@@ -1,0 +1,13 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import org.junit.Test;
+
+/**
+ * Created by mcharron on 2016-07-27.
+ */
+public class JenkinsCausesTest {
+    @Test(expected=IllegalAccessError.class)
+    public void givenProtectedConstructor_whenNew_throwIllegalAccess(){
+        new JenkinsCauses();
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackAbstractTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackAbstractTest.java
@@ -1,0 +1,19 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class LogbackAbstractTest implements LogbackFixture {
+
+    public String newSimpleLogbackXmlUrl() throws IOException {
+        Path logbackXml = newSimpleLogbackXmlPath();
+        return logbackXml.toUri().toURL().toString();
+    }
+
+    public Path newSimpleLogbackXmlPath() throws IOException {
+        Path logbackXml = Files.createTempFile(LogbackImplTest.class.getName(), ".xml");
+        Files.write(logbackXml, SIMPLE_LOGBACK_XML.getBytes());
+        return logbackXml;
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackFactoryTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackFactoryTest.java
@@ -1,0 +1,64 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertyLoader.class})
+public class LogbackFactoryTest extends LogbackAbstractTest {
+    Path logbackXmlPath;
+
+    @Before
+    public void setup() throws IOException {
+        mockStatic(PropertyLoader.class);
+        logbackXmlPath = newSimpleLogbackXmlPath();
+        Files.write(logbackXmlPath, SIMPLE_LOGBACK_XML.getBytes());
+        when(PropertyLoader.getLogbackConfigXmlUrl()).thenReturn(logbackXmlPath.toUri().toURL().toString());
+        when(PropertyLoader.getShouldSendToLogback()).thenReturn(true);
+    }
+
+    @Test
+    public void givenFactory_whenCreating_thenNewLogbackIsCreated() throws Exception {
+        Logback logback = LogbackFactory.create("fooLogger");
+
+        assertThat(logback, is(notNullValue()));
+        assertThat(logback.getLoggerName(), is("fooLogger"));
+    }
+
+    @Test
+    public void givenFactory_whenChangingLogbackXML_thenShouldReload() throws Exception {
+        Logback logback = LogbackFactory.create("foo");
+        URLSha initialSha = logback.getLastSha();
+
+        Files.write(logbackXmlPath, (SIMPLE_LOGBACK_XML + "\n\t").getBytes());
+        logback.refresh();
+
+        assertThat(logback.getLastSha(), is(not(equalTo(initialSha))));
+    }
+
+    @Test
+    public void givenFactory_whenRefreshing_thenShouldNotReload() throws Exception {
+        Logback logback = LogbackFactory.create("foo");
+        URLSha initialSha = logback.getLastSha();
+
+        logback.refresh();
+
+        assertThat(logback.getLastSha(), is(equalTo(initialSha)));
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackFixture.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackFixture.java
@@ -1,0 +1,19 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+public interface LogbackFixture {
+
+    String SIMPLE_LOGBACK_XML = "<configuration>\n" +
+            "\n" +
+            "  <appender name=\"STDOUT\" class=\"ch.qos.logback.core.ConsoleAppender\">\n" +
+            "    <!-- encoders are assigned the type\n" +
+            "         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->\n" +
+            "    <encoder>\n" +
+            "      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>\n" +
+            "    </encoder>\n" +
+            "  </appender>\n" +
+            "\n" +
+            "  <root level=\"debug\">\n" +
+            "    <appender-ref ref=\"STDOUT\" />\n" +
+            "  </root>\n" +
+            "</configuration>";
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImplTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImplTest.java
@@ -1,0 +1,97 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+
+import hudson.Plugin;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.any;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertyLoader.class, Jenkins.class})
+public class LogbackImplTest {
+
+    @Mock
+    Jenkins jenkinsMock;
+
+    Path logbackXml;
+
+    @Before
+    public void setup() throws IOException {
+        mockStatic(PropertyLoader.class);
+        mockStatic(Jenkins.class);
+
+        logbackXml = Files.createTempFile(LogbackImplTest.class.getName(), ".xml");
+        Files.write(logbackXml, ("<configuration>\n" +
+                "\n" +
+                "  <appender name=\"STDOUT\" class=\"ch.qos.logback.core.ConsoleAppender\">\n" +
+                "    <!-- encoders are assigned the type\n" +
+                "         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->\n" +
+                "    <encoder>\n" +
+                "      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>\n" +
+                "    </encoder>\n" +
+                "  </appender>\n" +
+                "\n" +
+                "  <root level=\"debug\">\n" +
+                "    <appender-ref ref=\"STDOUT\" />\n" +
+                "  </root>\n" +
+                "</configuration>").getBytes());
+    }
+
+    @Test
+    public void givenLogbackAppender_whenLogbackIsConfigured_thenLoggerIsCreated() throws MalformedURLException {
+        when(PropertyLoader.getLogbackConfigXmlUrl()).thenReturn(logbackXml.toFile().toURI().toURL().toString());
+        when(PropertyLoader.getShouldSendToLogback()).thenReturn(true);
+        when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        Plugin pluginMock = mock(Plugin.class);
+        when(jenkinsMock.getPlugin(LogbackUtil.LOGBACK_PLUGIN_NAME)).thenReturn(pluginMock);
+
+
+        LogbackUtil logbackUtil = new LogbackUtil();
+        logbackUtil.logInfo("something");
+
+        Logback logback = logbackUtil.getLogback();
+        assertThat(logback, is(notNullValue()));
+        assertThat(logback.getClass().getName(), is(LogbackImpl.class.getName()));
+
+        LogbackImpl logbackImpl = ((LogbackImpl) logback);
+        assertThat(logbackImpl.getLogger(), is(notNullValue()));
+    }
+
+    @Test
+    public void givenLogbackAppender_whenLogbackIsEnabledButNotConfigured_thenLoggerIsNotCreated() throws MalformedURLException {
+        when(PropertyLoader.getLogbackConfigXmlUrl()).thenReturn("");
+        when(PropertyLoader.getShouldSendToLogback()).thenReturn(true);
+        when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        Plugin pluginMock = mock(Plugin.class);
+        when(jenkinsMock.getPlugin(LogbackUtil.LOGBACK_PLUGIN_NAME)).thenReturn(pluginMock);
+
+
+        LogbackUtil logbackUtil = new LogbackUtil();
+        logbackUtil.logInfo("something");
+
+        Logback logback = logbackUtil.getLogback();
+        assertThat(logback, is(nullValue()));
+    }
+
+
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImplTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImplTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -16,7 +15,6 @@ import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,38 +26,24 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({PropertyLoader.class, Jenkins.class})
-public class LogbackImplTest {
+public class LogbackImplTest extends LogbackAbstractTest {
 
     @Mock
     Jenkins jenkinsMock;
 
-    Path logbackXml;
+    String logbackXml;
 
     @Before
     public void setup() throws IOException {
         mockStatic(PropertyLoader.class);
         mockStatic(Jenkins.class);
 
-        logbackXml = Files.createTempFile(LogbackImplTest.class.getName(), ".xml");
-        Files.write(logbackXml, ("<configuration>\n" +
-                "\n" +
-                "  <appender name=\"STDOUT\" class=\"ch.qos.logback.core.ConsoleAppender\">\n" +
-                "    <!-- encoders are assigned the type\n" +
-                "         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->\n" +
-                "    <encoder>\n" +
-                "      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>\n" +
-                "    </encoder>\n" +
-                "  </appender>\n" +
-                "\n" +
-                "  <root level=\"debug\">\n" +
-                "    <appender-ref ref=\"STDOUT\" />\n" +
-                "  </root>\n" +
-                "</configuration>").getBytes());
+        logbackXml = newSimpleLogbackXmlUrl();
     }
 
     @Test
     public void givenLogbackAppender_whenLogbackIsConfigured_thenLoggerIsCreated() throws MalformedURLException {
-        when(PropertyLoader.getLogbackConfigXmlUrl()).thenReturn(logbackXml.toFile().toURI().toURL().toString());
+        when(PropertyLoader.getLogbackConfigXmlUrl()).thenReturn(logbackXml);
         when(PropertyLoader.getShouldSendToLogback()).thenReturn(true);
         when(Jenkins.getInstance()).thenReturn(jenkinsMock);
         Plugin pluginMock = mock(Plugin.class);

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackUtilTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackUtilTest.java
@@ -1,0 +1,54 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import hudson.Plugin;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class, LogbackFactory.class, PropertyLoader.class})
+public class LogbackUtilTest {
+
+    @Mock
+    Jenkins jenkinsMock;
+
+    @Mock
+    Logback logbackMock;
+
+    @Before
+    public void setup() throws Exception {
+        mockStatic(Jenkins.class);
+        mockStatic(LogbackFactory.class);
+        mockStatic(PropertyLoader.class);
+        when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        when(PropertyLoader.getShouldSendToLogback()).thenReturn(true);
+        when(LogbackFactory.create(any(String.class))).thenReturn(logbackMock);
+    }
+
+    @Test
+    public void givenJenkinsWithoutLogback_whenLogging_thenDoNotCreateLogback() throws Exception {
+        when(jenkinsMock.getPlugin(LogbackUtil.LOGBACK_PLUGIN_NAME)).thenReturn(null);
+
+        new LogbackUtil().logInfo(new String("foo"));
+
+        verifyZeroInteractions(LogbackFactory.class);
+    }
+
+    @Test
+    public void givenJenkinsWithLogback_whenLogging_thenCreateLogback() throws Exception {
+        Plugin pluginMock = mock(Plugin.class);
+        when(jenkinsMock.getPlugin(LogbackUtil.LOGBACK_PLUGIN_NAME)).thenReturn(pluginMock);
+
+        new LogbackUtil().logInfo(new String("foo"));
+
+        verifyStatic(LogbackFactory.class);
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoaderTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoaderTest.java
@@ -61,6 +61,15 @@ public class PropertyLoaderTest {
     }
 
     @Test
+    public void givenResourceBundleWithoutProperty_whenGetKey_thenReturnNull(){
+        //given
+        //when
+        String property = PropertyLoader.getInstance().getResourceBundleProperty("non.existent.property");
+        //then
+        assertNull("Non existent properties should return null values", property);
+    }
+
+    @Test
     public void givenQueueUrl_whenGetQueueUrlEndpoint_thenReturnQueueUrl(){
         //given
         PowerMockito.mockStatic(StatisticsConfiguration.class);

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoaderTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoaderTest.java
@@ -81,11 +81,11 @@ public class PropertyLoaderTest {
         PowerMockito.mockStatic(Jenkins.class);
         Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
         Mockito.when(StatisticsConfiguration.get().getQueueUrl()).thenReturn(null);
-        Jenkins jenkincMock = mock(Jenkins.class);
+        Jenkins jenkinsMock = mock(Jenkins.class);
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
         Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
-        Mockito.when(jenkincMock.getGlobalNodeProperties()).thenReturn(describableList);
-        Mockito.when(Jenkins.getInstance()).thenReturn(jenkincMock);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
         //when
         String url = PropertyLoader.getQueueEndPoint();
 
@@ -100,7 +100,7 @@ public class PropertyLoaderTest {
         PowerMockito.mockStatic(Jenkins.class);
         Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
         Mockito.when(StatisticsConfiguration.get().getQueueUrl()).thenReturn(null);
-        Jenkins jenkincMock = mock(Jenkins.class);
+        Jenkins jenkinsMock = mock(Jenkins.class);
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
         List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
         EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
@@ -109,8 +109,8 @@ public class PropertyLoaderTest {
         Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
         environmentVariablesNodePropertyList.add(envVar);
         Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
-        Mockito.when(jenkincMock.getGlobalNodeProperties()).thenReturn(describableList);
-        Mockito.when(Jenkins.getInstance()).thenReturn(jenkincMock);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
         //when
         String url = PropertyLoader.getQueueEndPoint();
 
@@ -125,7 +125,7 @@ public class PropertyLoaderTest {
         PowerMockito.mockStatic(Jenkins.class);
         Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
         Mockito.when(StatisticsConfiguration.get().getQueueUrl()).thenReturn(null);
-        Jenkins jenkincMock = mock(Jenkins.class);
+        Jenkins jenkinsMock = mock(Jenkins.class);
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
         List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
         EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
@@ -134,8 +134,8 @@ public class PropertyLoaderTest {
         Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
         environmentVariablesNodePropertyList.add(envVar);
         Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
-        Mockito.when(jenkincMock.getGlobalNodeProperties()).thenReturn(describableList);
-        Mockito.when(Jenkins.getInstance()).thenReturn(jenkincMock);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
         //when
         String url = PropertyLoader.getQueueEndPoint();
 
@@ -183,11 +183,11 @@ public class PropertyLoaderTest {
         PowerMockito.mockStatic(Jenkins.class);
         Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
         Mockito.when(StatisticsConfiguration.get().getBuildUrl()).thenReturn(null);
-        Jenkins jenkincMock = mock(Jenkins.class);
+        Jenkins jenkinsMock = mock(Jenkins.class);
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
         Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
-        Mockito.when(jenkincMock.getGlobalNodeProperties()).thenReturn(describableList);
-        Mockito.when(Jenkins.getInstance()).thenReturn(jenkincMock);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
         //when
         String url = PropertyLoader.getBuildEndPoint();
 
@@ -202,7 +202,7 @@ public class PropertyLoaderTest {
         PowerMockito.mockStatic(Jenkins.class);
         Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
         Mockito.when(StatisticsConfiguration.get().getBuildUrl()).thenReturn(null);
-        Jenkins jenkincMock = mock(Jenkins.class);
+        Jenkins jenkinsMock = mock(Jenkins.class);
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
         List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
         EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
@@ -211,8 +211,8 @@ public class PropertyLoaderTest {
         Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
         environmentVariablesNodePropertyList.add(envVar);
         Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
-        Mockito.when(jenkincMock.getGlobalNodeProperties()).thenReturn(describableList);
-        Mockito.when(Jenkins.getInstance()).thenReturn(jenkincMock);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
         //when
         String url = PropertyLoader.getBuildEndPoint();
 
@@ -227,7 +227,7 @@ public class PropertyLoaderTest {
         PowerMockito.mockStatic(Jenkins.class);
         Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
         Mockito.when(StatisticsConfiguration.get().getBuildUrl()).thenReturn(null);
-        Jenkins jenkincMock = mock(Jenkins.class);
+        Jenkins jenkinsMock = mock(Jenkins.class);
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
         List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
         EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
@@ -236,8 +236,8 @@ public class PropertyLoaderTest {
         Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
         environmentVariablesNodePropertyList.add(envVar);
         Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
-        Mockito.when(jenkincMock.getGlobalNodeProperties()).thenReturn(describableList);
-        Mockito.when(Jenkins.getInstance()).thenReturn(jenkincMock);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
         //when
         String url = PropertyLoader.getBuildEndPoint();
 
@@ -285,11 +285,11 @@ public class PropertyLoaderTest {
         PowerMockito.mockStatic(Jenkins.class);
         Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
         Mockito.when(StatisticsConfiguration.get().getProjectUrl()).thenReturn(null);
-        Jenkins jenkincMock = mock(Jenkins.class);
+        Jenkins jenkinsMock = mock(Jenkins.class);
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
         Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
-        Mockito.when(jenkincMock.getGlobalNodeProperties()).thenReturn(describableList);
-        Mockito.when(Jenkins.getInstance()).thenReturn(jenkincMock);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
         //when
         String url = PropertyLoader.getProjectEndPoint();
 
@@ -304,7 +304,7 @@ public class PropertyLoaderTest {
         PowerMockito.mockStatic(Jenkins.class);
         Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
         Mockito.when(StatisticsConfiguration.get().getProjectUrl()).thenReturn(null);
-        Jenkins jenkincMock = mock(Jenkins.class);
+        Jenkins jenkinsMock = mock(Jenkins.class);
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
         List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
         EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
@@ -313,8 +313,8 @@ public class PropertyLoaderTest {
         Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
         environmentVariablesNodePropertyList.add(envVar);
         Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
-        Mockito.when(jenkincMock.getGlobalNodeProperties()).thenReturn(describableList);
-        Mockito.when(Jenkins.getInstance()).thenReturn(jenkincMock);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
         //when
         String url = PropertyLoader.getProjectEndPoint();
 
@@ -329,7 +329,7 @@ public class PropertyLoaderTest {
         PowerMockito.mockStatic(Jenkins.class);
         Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
         Mockito.when(StatisticsConfiguration.get().getProjectUrl()).thenReturn(null);
-        Jenkins jenkincMock = mock(Jenkins.class);
+        Jenkins jenkinsMock = mock(Jenkins.class);
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
         List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
         EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
@@ -338,8 +338,8 @@ public class PropertyLoaderTest {
         Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
         environmentVariablesNodePropertyList.add(envVar);
         Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
-        Mockito.when(jenkincMock.getGlobalNodeProperties()).thenReturn(describableList);
-        Mockito.when(Jenkins.getInstance()).thenReturn(jenkincMock);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
         //when
         String url = PropertyLoader.getProjectEndPoint();
 
@@ -382,5 +382,712 @@ public class PropertyLoaderTest {
         String property = PropertyLoader.getInstance().getProperty("");
         //then
         assertNull(property);
+    }
+
+    @Test
+    public void givenBuildStepUrl_whenGetBuildStepUrlEndpoint_thenReturnBuildStepUrl(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildStepUrl()).thenReturn("statistics.endpoint.buildStepUrl");
+        //when
+        String url = PropertyLoader.getBuildStepEndPoint();
+
+        //then
+        assertEquals("statistics.endpoint.buildStepUrl", url);
+    }
+
+    @Test
+    public void givenNoBuildStepUrl_whenGetBuildStepUrlEndpoint_thenReturnBuildStepUrl(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildStepUrl()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        String url = PropertyLoader.getBuildStepEndPoint();
+
+        //then
+        assertEquals("http://cistats.mycompany.com/api/buildSteps", url);
+    }
+
+    @Test
+    public void givenEnvVars_whenGetBuildStepUrlEndpoint_thenReturnBuildStepUrl(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildStepUrl()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<String, String>();
+        envVarMap.put("statistics.endpoint.buildStepUrl", "http://cistats.mycompany.com/api/");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        String url = PropertyLoader.getBuildStepEndPoint();
+
+        //then
+        assertEquals("http://cistats.mycompany.com/api/", url);
+    }
+
+    @Test
+    public void givenEmptyEnvVars_whenGetBuildStepUrlEndpoint_thenReturnBuildStepUrl(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildStepUrl()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<>();
+        envVarMap.put("statistics.endpoint.buildStepUrl", "");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        String url = PropertyLoader.getBuildStepEndPoint();
+
+        //then
+        assertEquals("http://cistats.mycompany.com/api/buildSteps", url);
+    }
+
+    @Test
+    public void givenEmptyBuildStepUrl_whenGetBuildStepUrlEndpoint_thenReturnBuildStepUrl(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildStepUrl()).thenReturn("");
+        Jenkins jenkinSMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinSMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinSMock);
+        //when
+        String url = PropertyLoader.getBuildStepEndPoint();
+
+        //then
+        assertEquals("http://cistats.mycompany.com/api/buildSteps", url);
+    }
+
+    @Test
+    public void givenScmCheckoutUrl_whenGetScmCheckoutUrlEndpoint_thenReturnScmCheckoutUrl(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getScmCheckoutUrl()).thenReturn("statistics.endpoint.scmCheckoutUrl");
+        //when
+        String url = PropertyLoader.getScmCheckoutEndPoint();
+
+        //then
+        assertEquals("statistics.endpoint.scmCheckoutUrl", url);
+    }
+
+    @Test
+    public void givenNoScmCheckoutUrl_whenGetScmCheckoutUrlEndpoint_thenReturnScmCheckoutUrl(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getScmCheckoutUrl()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        String url = PropertyLoader.getScmCheckoutEndPoint();
+
+        //then
+        assertEquals("http://cistats.mycompany.com/api/scmCheckouts", url);
+    }
+
+    @Test
+    public void givenEnvVars_whenGetScmCheckoutUrlEndpoint_thenReturnScmCheckoutUrl(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getScmCheckoutUrl()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<String, String>();
+        envVarMap.put("statistics.endpoint.scmCheckoutUrl", "http://cistats.mycompany.com/api/");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        String url = PropertyLoader.getScmCheckoutEndPoint();
+
+        //then
+        assertEquals("http://cistats.mycompany.com/api/", url);
+    }
+
+    @Test
+    public void givenEmptyEnvVars_whenGetScmCheckoutUrlEndpoint_thenReturnScmCheckoutUrl(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getScmCheckoutUrl()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<>();
+        envVarMap.put("statistics.endpoint.scmCheckoutUrl", "");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        String url = PropertyLoader.getScmCheckoutEndPoint();
+
+        //then
+        assertEquals("http://cistats.mycompany.com/api/scmCheckouts", url);
+    }
+
+    @Test
+    public void givenEmptyScmCheckoutUrl_whenGetScmCheckoutUrlEndpoint_thenReturnScmCheckoutUrl(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getScmCheckoutUrl()).thenReturn("");
+        Jenkins jenkinSMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinSMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinSMock);
+        //when
+        String url = PropertyLoader.getScmCheckoutEndPoint();
+
+        //then
+        assertEquals("http://cistats.mycompany.com/api/scmCheckouts", url);
+    }
+
+    @Test
+    public void givenScmCheckoutInfo_whenGetScmCheckoutInfo_thenReturnScmCheckoutInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getScmCheckoutInfo()).thenReturn(false);
+        //when
+        Boolean info = PropertyLoader.getScmCheckoutInfo();
+
+        //then
+        assertEquals(false, info);
+    }
+
+    @Test
+    public void givenNoScmCheckoutInfo_whenGetScmCheckoutInfoEndpoint_thenReturnScmCheckoutInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getScmCheckoutInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getScmCheckoutInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEnvVars_whenGetScmCheckoutInfoEndpoint_thenReturnScmCheckoutInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getScmCheckoutInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<String, String>();
+        envVarMap.put("statistics.endpoint.scmCheckoutInfo", "true");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getScmCheckoutInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEmptyEnvVars_whenGetScmCheckoutInfoEndpoint_thenReturnScmCheckoutInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getScmCheckoutInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<>();
+        envVarMap.put("statistics.endpoint.scmCheckoutInfo", "");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getScmCheckoutInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEmptyScmCheckoutInfo_whenGetScmCheckoutInfoEndpoint_thenReturnScmCheckoutInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getScmCheckoutInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getScmCheckoutInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenBuildStepInfo_whenGetBuildStepInfo_thenReturnBuildStepInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildStepInfo()).thenReturn(false);
+        //when
+        Boolean info = PropertyLoader.getBuildStepInfo();
+
+        //then
+        assertEquals(false, info);
+    }
+
+    @Test
+    public void givenNoBuildStepInfo_whenGetBuildStepInfoEndpoint_thenReturnBuildStepInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildStepInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getBuildStepInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEnvVars_whenGetBuildStepInfoEndpoint_thenReturnBuildStepInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildStepInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<String, String>();
+        envVarMap.put("statistics.endpoint.buildStepInfo", "true");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getBuildStepInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEmptyEnvVars_whenGetBuildStepInfoEndpoint_thenReturnBuildStepInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildStepInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<>();
+        envVarMap.put("statistics.endpoint.buildStepInfo", "");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getBuildStepInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEmptyBuildStepInfo_whenGetBuildStepInfoEndpoint_thenReturnBuildStepInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildStepInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getBuildStepInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenBuildInfo_whenGetBuildInfo_thenReturnBuildInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildInfo()).thenReturn(false);
+        //when
+        Boolean info = PropertyLoader.getBuildInfo();
+
+        //then
+        assertEquals(false, info);
+    }
+
+    @Test
+    public void givenNoBuildInfo_whenGetBuildInfoEndpoint_thenReturnBuildInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getBuildInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEnvVars_whenGetBuildInfoEndpoint_thenReturnBuildInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<String, String>();
+        envVarMap.put("statistics.endpoint.buildInfo", "true");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getBuildInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEmptyEnvVars_whenGetBuildInfoEndpoint_thenReturnBuildInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<>();
+        envVarMap.put("statistics.endpoint.buildInfo", "");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getBuildInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEmptyBuildInfo_whenGetBuildInfoEndpoint_thenReturnBuildInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getBuildInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getBuildInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenQueueInfo_whenGetQueueInfo_thenReturnQueueInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getQueueInfo()).thenReturn(false);
+        //when
+        Boolean info = PropertyLoader.getQueueInfo();
+
+        //then
+        assertEquals(false, info);
+    }
+
+    @Test
+    public void givenNoQueueInfo_whenGetQueueInfoEndpoint_thenReturnQueueInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getQueueInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getQueueInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEnvVars_whenGetQueueInfoEndpoint_thenReturnQueueInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getQueueInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<String, String>();
+        envVarMap.put("statistics.endpoint.queueInfo", "true");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getQueueInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEmptyEnvVars_whenGetQueueInfoEndpoint_thenReturnQueueInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getQueueInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<>();
+        envVarMap.put("statistics.endpoint.queueInfo", "");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getQueueInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEmptyQueueInfo_whenGetQueueInfoEndpoint_thenReturnQueueInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getQueueInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getQueueInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenProjectInfo_whenGetProjectInfo_thenReturnProjectInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getProjectInfo()).thenReturn(false);
+        //when
+        Boolean info = PropertyLoader.getProjectInfo();
+
+        //then
+        assertEquals(false, info);
+    }
+
+    @Test
+    public void givenNoProjectInfo_whenGetProjectInfoEndpoint_thenReturnProjectInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getProjectInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getProjectInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEnvVars_whenGetProjectInfoEndpoint_thenReturnProjectInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getProjectInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<EnvironmentVariablesNodeProperty>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<String, String>();
+        envVarMap.put("statistics.endpoint.projectInfo", "true");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getProjectInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEmptyEnvVars_whenGetProjectInfoEndpoint_thenReturnProjectInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getProjectInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        List<EnvironmentVariablesNodeProperty> environmentVariablesNodePropertyList = new ArrayList<>();
+        EnvironmentVariablesNodeProperty envVar = mock(EnvironmentVariablesNodeProperty.class);
+        Map<String, String> envVarMap = new HashMap<>();
+        envVarMap.put("statistics.endpoint.projectInfo", "");
+        Mockito.when(envVar.getEnvVars()).thenReturn(new EnvVars(envVarMap));
+        environmentVariablesNodePropertyList.add(envVar);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(environmentVariablesNodePropertyList);
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getProjectInfo();
+
+        //then
+        assertEquals(true, info);
+    }
+
+    @Test
+    public void givenEmptyProjectInfo_whenGetProjectInfoEndpoint_thenReturnProjectInfo(){
+        //given
+        PowerMockito.mockStatic(StatisticsConfiguration.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(StatisticsConfiguration.get()).thenReturn(mock(StatisticsConfiguration.class));
+        Mockito.when(StatisticsConfiguration.get().getProjectInfo()).thenReturn(null);
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> describableList = mock(DescribableList.class);
+        Mockito.when(describableList.getAll(EnvironmentVariablesNodeProperty.class)).thenReturn(new ArrayList<EnvironmentVariablesNodeProperty>());
+        Mockito.when(jenkinsMock.getGlobalNodeProperties()).thenReturn(describableList);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        //when
+        Boolean info = PropertyLoader.getProjectInfo();
+
+        //then
+        assertEquals(true, info);
     }
 }

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtilTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtilTest.java
@@ -1,0 +1,38 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import com.mashape.unirest.http.Unirest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Unirest.class, PropertyLoader.class})
+public class RestClientUtilTest {
+
+    @Before
+    public void setup() {
+        mockStatic(Unirest.class);
+        mockStatic(PropertyLoader.class);
+    }
+
+    @Test
+    public void whenRestApiFails_thenShouldContinue() throws Exception {
+        when(Unirest.post(anyString())).thenThrow(new IllegalArgumentException("Some error occurred"));
+        when(PropertyLoader.getShouldSendApiHttpRequests()).thenReturn(true);
+
+        try {
+            RestClientUtil.postToService("http://foo", new String("bar"));
+        } catch (Throwable e) {
+            fail("Should not have thrown any exception here");
+        }
+    }
+}

--- a/src/test/resources/statistics.properties
+++ b/src/test/resources/statistics.properties
@@ -1,3 +1,10 @@
 statistics.endpoint.queueUrl=http://cistats.mycompany.com/api/queues
 statistics.endpoint.buildUrl=http://cistats.mycompany.com/api/builds
 statistics.endpoint.projectUrl=http://cistats.mycompany.com/api/projects
+statistics.endpoint.buildStepUrl=http://cistats.mycompany.com/api/buildSteps
+statistics.endpoint.scmCheckoutUrl=http://cistats.mycompany.com/api/scmCheckouts
+statistics.endpoint.queueInfo=true
+statistics.endpoint.buildInfo=true
+statistics.endpoint.projectInfo=true
+statistics.endpoint.buildStepInfo=true
+statistics.endpoint.scmCheckoutInfo=true


### PR DESCRIPTION
Fixes three issues:

If Jenkins uses authorization, authorization is denied when querying to "/api/json?depth=2&tree=actions[foundFailureCauses[categories,description,id,name]]"
- Added two new fields in configuration screen to allow entry of Jenkins username and token, which will be used as username/password when posting the GET request
addBuildFailureCauses function tried to parse JSON without an array and fails
- added a check in case array is empty
convertBuildFailureToMap raises an exception when Category is set to empty
- added a check to ensure rest of information is returned